### PR TITLE
경기장 CRUD, 구역 CRUD, 좌석 CRUD 구현

### DIFF
--- a/src/main/java/com/example/ticketable/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/ticketable/common/exception/ErrorCode.java
@@ -15,8 +15,8 @@ public enum ErrorCode {
 	STADIUM_NOT_FOUND("해당하는 경기장을 찾을 수 없습니다.", NOT_FOUND),
 	SECTION_NOT_FOUND("해당하는 구역을 찾을 수 없습니다.", NOT_FOUND),
 	SEAT_NOT_FOUND("해당하는 좌석을 찾을 수 없습니다.", NOT_FOUND),
-	COLUMN_NUMS_AND_BLIND_STATUS_NOT_SAME_SIZE("열 번호와 시야 방해 여부 리스트의 크기는 같아야 합니다.", HttpStatus.BAD_REQUEST),
-	BLIND_STATUS_ALREADY_SET("시야 방해석 상태가 이미 요청된 상태와 동일합니다.", HttpStatus.BAD_REQUEST),
+	COLUMN_NUMS_AND_BLIND_STATUS_NOT_SAME_SIZE("열 번호와 시야 방해 여부 리스트의 크기는 같아야 합니다.", BAD_REQUEST),
+	BLIND_STATUS_ALREADY_SET("시야 방해석 상태가 이미 요청된 상태와 동일합니다.", BAD_REQUEST),
 	SEATS_ALREADY_EXISTS("이미 구역에 좌석이 있습니다.", BAD_REQUEST),
 
 	// 티켓

--- a/src/main/java/com/example/ticketable/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/ticketable/common/exception/ErrorCode.java
@@ -12,7 +12,7 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 public enum ErrorCode {
 	
 	// 경기장
-	
+	STADIUM_NOT_FOUND("해당하는 경기장을 찾을 수 없습니다.", NOT_FOUND),
 	// 티켓
 	
 	// 경매

--- a/src/main/java/com/example/ticketable/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/ticketable/common/exception/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
 	STADIUM_NOT_FOUND("해당하는 경기장을 찾을 수 없습니다.", NOT_FOUND),
 	SECTION_NOT_FOUND("해당하는 구역을 찾을 수 없습니다.", NOT_FOUND),
 	SEAT_NOT_FOUND("해당하는 좌석을 찾을 수 없습니다.", NOT_FOUND),
+	COLUMN_NUMS_AND_BLIND_STATUS_NOT_SAME_SIZE("열 번호와 시야 방해 여부 리스트의 크기는 같아야 합니다.", HttpStatus.BAD_REQUEST),
 	// 티켓
 	
 	// 경매

--- a/src/main/java/com/example/ticketable/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/ticketable/common/exception/ErrorCode.java
@@ -13,6 +13,8 @@ public enum ErrorCode {
 	
 	// 경기장
 	STADIUM_NOT_FOUND("해당하는 경기장을 찾을 수 없습니다.", NOT_FOUND),
+	SECTION_NOT_FOUND("해당하는 구역을 찾을 수 없습니다.", NOT_FOUND),
+	SEAT_NOT_FOUND("해당하는 좌석을 찾을 수 없습니다.", NOT_FOUND),
 	// 티켓
 	
 	// 경매

--- a/src/main/java/com/example/ticketable/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/ticketable/common/exception/ErrorCode.java
@@ -16,6 +16,9 @@ public enum ErrorCode {
 	SECTION_NOT_FOUND("해당하는 구역을 찾을 수 없습니다.", NOT_FOUND),
 	SEAT_NOT_FOUND("해당하는 좌석을 찾을 수 없습니다.", NOT_FOUND),
 	COLUMN_NUMS_AND_BLIND_STATUS_NOT_SAME_SIZE("열 번호와 시야 방해 여부 리스트의 크기는 같아야 합니다.", HttpStatus.BAD_REQUEST),
+	BLIND_STATUS_ALREADY_SET("시야 방해석 상태가 이미 요청된 상태와 동일합니다.", HttpStatus.BAD_REQUEST),
+	SEATS_ALREADY_EXISTS("이미 구역에 좌석이 있습니다.", BAD_REQUEST),
+
 	// 티켓
 	
 	// 경매

--- a/src/main/java/com/example/ticketable/domain/stadium/controller/SeatController.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/controller/SeatController.java
@@ -1,7 +1,35 @@
 package com.example.ticketable.domain.stadium.controller;
 
-import org.springframework.web.bind.annotation.RestController;
+import com.example.ticketable.domain.stadium.dto.request.SeatCreateRequest;
+import com.example.ticketable.domain.stadium.dto.response.SeatCreateResponse;
+import com.example.ticketable.domain.stadium.dto.response.SeatGetResponse;
+import com.example.ticketable.domain.stadium.service.SeatService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
 
 @RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/stadiums/{stadiumId}/sections/{sectionId}/seats")
 public class SeatController {
+    private final SeatService seatService;
+
+    @PostMapping
+    public ResponseEntity<List<SeatCreateResponse>> createSeats(
+        @PathVariable Long sectionId,
+        @RequestBody SeatCreateRequest request
+    ) {
+        return ResponseEntity.ok(seatService.createSeats(sectionId, request));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<SeatGetResponse>> getSeats(
+            @PathVariable Long sectionId
+    ) {
+        return ResponseEntity.ok(seatService.getSeats(sectionId));
+    }
+
 }

--- a/src/main/java/com/example/ticketable/domain/stadium/controller/SeatController.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/controller/SeatController.java
@@ -15,11 +15,11 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/stadiums/{stadiumId}/sections/{sectionId}/seats")
+@RequestMapping("/api")
 public class SeatController {
     private final SeatService seatService;
 
-    @PostMapping
+    @PostMapping("/v1/stadiums/{stadiumId}/sections/{sectionId}/seats")
     public ResponseEntity<List<SeatCreateResponse>> createSeats(
             @PathVariable Long stadiumId,
             @PathVariable Long sectionId,
@@ -28,14 +28,14 @@ public class SeatController {
         return ResponseEntity.ok(seatService.createSeats(stadiumId, sectionId, request));
     }
 
-    @GetMapping
+    @GetMapping("/v1/stadiums/{stadiumId}/sections/{sectionId}/seats")
     public ResponseEntity<List<SeatGetResponse>> getSeats(
             @PathVariable Long sectionId
     ) {
         return ResponseEntity.ok(seatService.getSeats(sectionId));
     }
 
-    @PutMapping("/{seatId}")
+    @PutMapping("/v1/stadiums/{stadiumId}/sections/{sectionId}/seats/{seatId}")
     public ResponseEntity<SeatUpdateResponse> updateSeat(
             @PathVariable Long seatId,
             @RequestBody SeatUpdateRequest request
@@ -43,7 +43,7 @@ public class SeatController {
         return ResponseEntity.ok(seatService.updateSeat(seatId, request));
     }
 
-    @DeleteMapping("/{seatId}")
+    @DeleteMapping("/v1/stadiums/{stadiumId}/sections/{sectionId}/seats/{seatId}")
     public ResponseEntity<Void> deleteSeat(
             @PathVariable Long seatId
     ) {

--- a/src/main/java/com/example/ticketable/domain/stadium/controller/SeatController.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/controller/SeatController.java
@@ -1,8 +1,10 @@
 package com.example.ticketable.domain.stadium.controller;
 
 import com.example.ticketable.domain.stadium.dto.request.SeatCreateRequest;
+import com.example.ticketable.domain.stadium.dto.request.SeatUpdateRequest;
 import com.example.ticketable.domain.stadium.dto.response.SeatCreateResponse;
 import com.example.ticketable.domain.stadium.dto.response.SeatGetResponse;
+import com.example.ticketable.domain.stadium.dto.response.SeatUpdateResponse;
 import com.example.ticketable.domain.stadium.service.SeatService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -19,10 +21,11 @@ public class SeatController {
 
     @PostMapping
     public ResponseEntity<List<SeatCreateResponse>> createSeats(
-        @PathVariable Long sectionId,
-        @RequestBody SeatCreateRequest request
+            @PathVariable Long stadiumId,
+            @PathVariable Long sectionId,
+            @RequestBody SeatCreateRequest request
     ) {
-        return ResponseEntity.ok(seatService.createSeats(sectionId, request));
+        return ResponseEntity.ok(seatService.createSeats(stadiumId, sectionId, request));
     }
 
     @GetMapping
@@ -32,4 +35,19 @@ public class SeatController {
         return ResponseEntity.ok(seatService.getSeats(sectionId));
     }
 
+    @PutMapping("/{seatId}")
+    public ResponseEntity<SeatUpdateResponse> updateSeat(
+            @PathVariable Long seatId,
+            @RequestBody SeatUpdateRequest request
+    ) {
+        return ResponseEntity.ok(seatService.updateSeat(seatId, request));
+    }
+
+    @DeleteMapping("/{seatId}")
+    public ResponseEntity<Void> deleteSeat(
+            @PathVariable Long seatId
+    ) {
+        seatService.delete(seatId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/example/ticketable/domain/stadium/controller/SectionController.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/controller/SectionController.java
@@ -14,11 +14,11 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/stadiums/{stadiumId}/sections")
+@RequestMapping("/api")
 public class SectionController {
     private final SectionService sectionService;
 
-    @PostMapping
+    @PostMapping("/v1/stadiums/{stadiumId}/sections")
     public ResponseEntity<SectionCreateResponse> createSection(
             @PathVariable Long stadiumId,
             @RequestBody SectionCreateRequest request
@@ -26,7 +26,7 @@ public class SectionController {
         return ResponseEntity.ok(sectionService.createSection(stadiumId, request));
     }
 
-    @GetMapping
+    @GetMapping("/v1/stadiums/{stadiumId}/sections")
     public ResponseEntity<List<SectionSeatCountResponse>> getAvailableSeatsBySectionCode(
             @PathVariable Long stadiumId,
             @RequestParam String type
@@ -34,7 +34,7 @@ public class SectionController {
         return ResponseEntity.ok(sectionService.getAvailableSeatsBySectionCode(stadiumId, type));
     }
 
-    @PutMapping("/{sectionId}")
+    @PutMapping("/v1/stadiums/{stadiumId}/sections/{sectionId}")
     public ResponseEntity<SectionUpdateResponse> updateSection(
             @PathVariable Long sectionId,
             @RequestBody SectionUpdateRequest request
@@ -43,7 +43,7 @@ public class SectionController {
     }
 
 
-    @DeleteMapping("/{sectionId}")
+    @DeleteMapping("/v1/stadiums/{stadiumId}/sections/{sectionId}")
     public ResponseEntity<Void> deleteSection(
             @PathVariable Long sectionId
     ) {

--- a/src/main/java/com/example/ticketable/domain/stadium/controller/SectionController.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/controller/SectionController.java
@@ -4,4 +4,5 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class SectionController {
+
 }

--- a/src/main/java/com/example/ticketable/domain/stadium/controller/SectionController.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/controller/SectionController.java
@@ -1,8 +1,42 @@
 package com.example.ticketable.domain.stadium.controller;
 
-import org.springframework.web.bind.annotation.RestController;
+import com.example.ticketable.domain.stadium.dto.request.SectionCreateRequest;
+import com.example.ticketable.domain.stadium.dto.request.SectionUpdateRequest;
+import com.example.ticketable.domain.stadium.dto.response.SectionCreateResponse;
+import com.example.ticketable.domain.stadium.dto.response.SectionUpdateResponse;
+import com.example.ticketable.domain.stadium.service.SectionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/stadiums/{stadiumId}/sections")
 public class SectionController {
+    private final SectionService sectionService;
 
+    @PostMapping
+    public ResponseEntity<SectionCreateResponse> createSection(
+            @PathVariable Long stadiumId,
+            @RequestBody SectionCreateRequest request
+    ) {
+        return ResponseEntity.ok(sectionService.createSection(stadiumId, request));
+    }
+
+    @PutMapping("/{sectionId}")
+    public ResponseEntity<SectionUpdateResponse> updateSection(
+            @PathVariable Long sectionId,
+            @RequestBody SectionUpdateRequest request
+    ) {
+        return ResponseEntity.ok(sectionService.updateSection(sectionId, request));
+    }
+
+
+    @DeleteMapping("/{sectionId}")
+    public ResponseEntity<Void> deleteSection(
+            @PathVariable Long sectionId
+    ) {
+        sectionService.delete(sectionId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/example/ticketable/domain/stadium/controller/SectionController.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/controller/SectionController.java
@@ -3,11 +3,14 @@ package com.example.ticketable.domain.stadium.controller;
 import com.example.ticketable.domain.stadium.dto.request.SectionCreateRequest;
 import com.example.ticketable.domain.stadium.dto.request.SectionUpdateRequest;
 import com.example.ticketable.domain.stadium.dto.response.SectionCreateResponse;
+import com.example.ticketable.domain.stadium.dto.response.SectionSeatCountResponse;
 import com.example.ticketable.domain.stadium.dto.response.SectionUpdateResponse;
 import com.example.ticketable.domain.stadium.service.SectionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,6 +24,14 @@ public class SectionController {
             @RequestBody SectionCreateRequest request
     ) {
         return ResponseEntity.ok(sectionService.createSection(stadiumId, request));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<SectionSeatCountResponse>> getAvailableSeatsBySectionCode(
+            @PathVariable Long stadiumId,
+            @RequestParam String type
+    ) {
+        return ResponseEntity.ok(sectionService.getAvailableSeatsBySectionCode(stadiumId, type));
     }
 
     @PutMapping("/{sectionId}")

--- a/src/main/java/com/example/ticketable/domain/stadium/controller/StadiumController.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/controller/StadiumController.java
@@ -1,7 +1,26 @@
 package com.example.ticketable.domain.stadium.controller;
 
-import org.springframework.web.bind.annotation.RestController;
+import com.example.ticketable.domain.stadium.dto.request.StadiumCreateRequest;
+import com.example.ticketable.domain.stadium.dto.response.StadiumCreateResponse;
+import com.example.ticketable.domain.stadium.dto.response.StadiumGetResponse;
+import com.example.ticketable.domain.stadium.service.StadiumService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/stadiums")
 public class StadiumController {
+    private final StadiumService stadiumService;
+
+    @PostMapping
+    public ResponseEntity<StadiumCreateResponse> createStadium(@RequestBody StadiumCreateRequest request) {
+        return ResponseEntity.ok(stadiumService.createStadium(request));
+    }
+
+    @GetMapping("{stadiumId}")
+    public ResponseEntity<StadiumGetResponse> getStadium(@PathVariable Long stadiumId) {
+        return ResponseEntity.ok(stadiumService.getStadium(stadiumId));
+    }
 }

--- a/src/main/java/com/example/ticketable/domain/stadium/controller/StadiumController.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/controller/StadiumController.java
@@ -1,8 +1,10 @@
 package com.example.ticketable.domain.stadium.controller;
 
 import com.example.ticketable.domain.stadium.dto.request.StadiumCreateRequest;
+import com.example.ticketable.domain.stadium.dto.request.StadiumUpdateRequest;
 import com.example.ticketable.domain.stadium.dto.response.StadiumCreateResponse;
 import com.example.ticketable.domain.stadium.dto.response.StadiumGetResponse;
+import com.example.ticketable.domain.stadium.dto.response.StadiumUpdateResponse;
 import com.example.ticketable.domain.stadium.service.StadiumService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -22,5 +24,19 @@ public class StadiumController {
     @GetMapping("{stadiumId}")
     public ResponseEntity<StadiumGetResponse> getStadium(@PathVariable Long stadiumId) {
         return ResponseEntity.ok(stadiumService.getStadium(stadiumId));
+    }
+
+    @PatchMapping("{stadiumId}")
+    public ResponseEntity<StadiumUpdateResponse> updateStadium(
+            @PathVariable Long stadiumId,
+            @RequestBody StadiumUpdateRequest requset
+    ) {
+        return ResponseEntity.ok(stadiumService.updateStadium(stadiumId, requset));
+    }
+
+    @DeleteMapping("{stadiumId}")
+    public ResponseEntity<Void> deleteStadium(@PathVariable Long stadiumId) {
+        stadiumService.deleteStadium(stadiumId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/example/ticketable/domain/stadium/controller/StadiumController.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/controller/StadiumController.java
@@ -23,10 +23,10 @@ public class StadiumController {
 
     @GetMapping("{stadiumId}")
     public ResponseEntity<StadiumGetResponse> getStadium(@PathVariable Long stadiumId) {
-        return ResponseEntity.ok(stadiumService.getStadium(stadiumId));
+        return ResponseEntity.ok(stadiumService.getStadiumDto(stadiumId));
     }
 
-    @PatchMapping("{stadiumId}")
+    @PutMapping("{stadiumId}")
     public ResponseEntity<StadiumUpdateResponse> updateStadium(
             @PathVariable Long stadiumId,
             @RequestBody StadiumUpdateRequest requset

--- a/src/main/java/com/example/ticketable/domain/stadium/controller/StadiumController.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/controller/StadiumController.java
@@ -12,21 +12,21 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/stadiums")
+@RequestMapping("/api")
 public class StadiumController {
     private final StadiumService stadiumService;
 
-    @PostMapping
+    @PostMapping("/v1/stadiums")
     public ResponseEntity<StadiumCreateResponse> createStadium(@RequestBody StadiumCreateRequest request) {
         return ResponseEntity.ok(stadiumService.createStadium(request));
     }
 
-    @GetMapping("{stadiumId}")
+    @GetMapping("/v1/stadiums/{stadiumId}")
     public ResponseEntity<StadiumGetResponse> getStadium(@PathVariable Long stadiumId) {
         return ResponseEntity.ok(stadiumService.getStadiumDto(stadiumId));
     }
 
-    @PutMapping("{stadiumId}")
+    @PutMapping("/v1/stadiums/{stadiumId}")
     public ResponseEntity<StadiumUpdateResponse> updateStadium(
             @PathVariable Long stadiumId,
             @RequestBody StadiumUpdateRequest requset
@@ -34,7 +34,7 @@ public class StadiumController {
         return ResponseEntity.ok(stadiumService.updateStadium(stadiumId, requset));
     }
 
-    @DeleteMapping("{stadiumId}")
+    @DeleteMapping("/v1/stadiums/{stadiumId}")
     public ResponseEntity<Void> deleteStadium(@PathVariable Long stadiumId) {
         stadiumService.deleteStadium(stadiumId);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/example/ticketable/domain/stadium/dto/request/SeatCreateRequest.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/dto/request/SeatCreateRequest.java
@@ -1,0 +1,19 @@
+package com.example.ticketable.domain.stadium.dto.request;
+
+import com.example.ticketable.domain.stadium.entity.Seat;
+import com.example.ticketable.domain.stadium.entity.Section;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class SeatCreateRequest {
+    private List<List<String>> colNums;
+
+    private List<List<Boolean>> isBlind;
+
+    public SeatCreateRequest(List<List<String>> colNums, List<List<Boolean>> isBlind) {
+        this.colNums = colNums;
+        this.isBlind = isBlind;
+    }
+}

--- a/src/main/java/com/example/ticketable/domain/stadium/dto/request/SeatUpdateRequest.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/dto/request/SeatUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.example.ticketable.domain.stadium.dto.request;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class SeatUpdateRequest {
+
+    private boolean isBlind;
+
+    public SeatUpdateRequest(boolean isBlind) {
+        this.isBlind = isBlind;
+    }
+}

--- a/src/main/java/com/example/ticketable/domain/stadium/dto/request/SectionCreateRequest.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/dto/request/SectionCreateRequest.java
@@ -16,12 +16,4 @@ public class SectionCreateRequest {
         this.code = code;
         this.extraCharge = extraCharge;
     }
-
-    public static SectionCreateRequest of(Section section) {
-        return new SectionCreateRequest(
-                section.getType(),
-                section.getCode(),
-                section.getExtraCharge()
-        );
-    }
 }

--- a/src/main/java/com/example/ticketable/domain/stadium/dto/request/SectionCreateRequest.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/dto/request/SectionCreateRequest.java
@@ -1,0 +1,27 @@
+package com.example.ticketable.domain.stadium.dto.request;
+
+import com.example.ticketable.domain.stadium.entity.Section;
+import lombok.Getter;
+
+@Getter
+public class SectionCreateRequest {
+    private String type;
+
+    private String code;
+
+    private Integer extraCharge;
+
+    public SectionCreateRequest(String type, String code, Integer extraCharge) {
+        this.type = type;
+        this.code = code;
+        this.extraCharge = extraCharge;
+    }
+
+    public static SectionCreateRequest of(Section section) {
+        return new SectionCreateRequest(
+                section.getType(),
+                section.getCode(),
+                section.getExtraCharge()
+        );
+    }
+}

--- a/src/main/java/com/example/ticketable/domain/stadium/dto/request/SectionUpdateRequest.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/dto/request/SectionUpdateRequest.java
@@ -16,12 +16,4 @@ public class SectionUpdateRequest {
         this.code = code;
         this.extraCharge = extraCharge;
     }
-
-    public static SectionUpdateRequest of(Section section) {
-        return new SectionUpdateRequest(
-                section.getType(),
-                section.getCode(),
-                section.getExtraCharge()
-        );
-    }
 }

--- a/src/main/java/com/example/ticketable/domain/stadium/dto/request/SectionUpdateRequest.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/dto/request/SectionUpdateRequest.java
@@ -1,0 +1,27 @@
+package com.example.ticketable.domain.stadium.dto.request;
+
+import com.example.ticketable.domain.stadium.entity.Section;
+import lombok.Getter;
+
+@Getter
+public class SectionUpdateRequest {
+    private String type;
+
+    private String code;
+
+    private Integer extraCharge;
+
+    public SectionUpdateRequest(String type, String code, Integer extraCharge) {
+        this.type = type;
+        this.code = code;
+        this.extraCharge = extraCharge;
+    }
+
+    public static SectionUpdateRequest of(Section section) {
+        return new SectionUpdateRequest(
+                section.getType(),
+                section.getCode(),
+                section.getExtraCharge()
+        );
+    }
+}

--- a/src/main/java/com/example/ticketable/domain/stadium/dto/request/StadiumCreateRequest.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/dto/request/StadiumCreateRequest.java
@@ -1,0 +1,15 @@
+package com.example.ticketable.domain.stadium.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class StadiumCreateRequest {
+    private String name;
+
+    private String location;
+
+    public StadiumCreateRequest(String name, String location) {
+        this.name = name;
+        this.location = location;
+    }
+}

--- a/src/main/java/com/example/ticketable/domain/stadium/dto/request/StadiumUpdateRequest.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/dto/request/StadiumUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.example.ticketable.domain.stadium.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class StadiumUpdateRequest {
+    private String name;
+    public StadiumUpdateRequest(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/example/ticketable/domain/stadium/dto/response/SeatCreateResponse.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/dto/response/SeatCreateResponse.java
@@ -1,0 +1,29 @@
+package com.example.ticketable.domain.stadium.dto.response;
+
+import com.example.ticketable.domain.stadium.entity.Seat;
+import com.example.ticketable.domain.stadium.entity.Section;
+import lombok.Getter;
+
+@Getter
+public class SeatCreateResponse {
+    private final Long id;
+
+    private final String position;
+
+    private final boolean isBlind;
+
+
+    public SeatCreateResponse(Long id, String position, boolean isBlind) {
+        this.id = id;
+        this.position = position;
+        this.isBlind = isBlind;
+    }
+
+    public static SeatCreateResponse of(Seat seat) {
+        return new SeatCreateResponse(
+                seat.getId(),
+                seat.getPosition(),
+                seat.isBlind()
+        );
+    }
+}

--- a/src/main/java/com/example/ticketable/domain/stadium/dto/response/SeatGetResponse.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/dto/response/SeatGetResponse.java
@@ -1,0 +1,31 @@
+package com.example.ticketable.domain.stadium.dto.response;
+
+import com.example.ticketable.domain.stadium.entity.Seat;
+import lombok.Getter;
+
+@Getter
+public class SeatGetResponse {
+    private final Long id;
+
+    private final String position;
+
+    private final boolean isBlind;
+
+    private final boolean isBooked;
+
+    public SeatGetResponse(Long id, String position, boolean isBlind, boolean isBooked) {
+        this.id = id;
+        this.position = position;
+        this.isBlind = isBlind;
+        this.isBooked = isBooked;
+    }
+
+    public static SeatGetResponse of(Seat seat, boolean isBooked) {
+        return new SeatGetResponse(
+                seat.getId(),
+                seat.getPosition(),
+                seat.isBlind(),
+                isBooked
+        );
+    }
+}

--- a/src/main/java/com/example/ticketable/domain/stadium/dto/response/SeatUpdateResponse.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/dto/response/SeatUpdateResponse.java
@@ -1,0 +1,28 @@
+package com.example.ticketable.domain.stadium.dto.response;
+
+import com.example.ticketable.domain.stadium.entity.Seat;
+import lombok.Getter;
+
+@Getter
+public class SeatUpdateResponse {
+    private final Long id;
+
+    private final String position;
+
+    private final boolean isBlind;
+
+
+    public SeatUpdateResponse(Long id, String position, boolean isBlind) {
+        this.id = id;
+        this.position = position;
+        this.isBlind = isBlind;
+    }
+
+    public static SeatUpdateResponse of(Seat seat) {
+        return new SeatUpdateResponse(
+                seat.getId(),
+                seat.getPosition(),
+                seat.isBlind()
+        );
+    }
+}

--- a/src/main/java/com/example/ticketable/domain/stadium/dto/response/SectionCreateResponse.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/dto/response/SectionCreateResponse.java
@@ -1,0 +1,33 @@
+package com.example.ticketable.domain.stadium.dto.response;
+
+import com.example.ticketable.domain.stadium.entity.Section;
+import com.example.ticketable.domain.stadium.entity.Stadium;
+import lombok.Getter;
+
+@Getter
+public class SectionCreateResponse {
+    private final Long id;
+
+    private final String type;
+
+    private final String code;
+
+    private final Integer extraCharge;
+
+
+    public SectionCreateResponse(Long id, String type, String code, Integer extraCharge) {
+        this.id = id;
+        this.type = type;
+        this.code = code;
+        this.extraCharge = extraCharge;
+    }
+
+    public static SectionCreateResponse of(Section section) {
+        return new SectionCreateResponse(
+                section.getId(),
+                section.getType(),
+                section.getCode(),
+                section.getExtraCharge()
+        );
+    }
+}

--- a/src/main/java/com/example/ticketable/domain/stadium/dto/response/SectionSeatCountResponse.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/dto/response/SectionSeatCountResponse.java
@@ -1,0 +1,15 @@
+package com.example.ticketable.domain.stadium.dto.response;
+
+
+import lombok.Getter;
+
+@Getter
+public class SectionSeatCountResponse {
+    private final String sectionCode;
+    private final Long seatCount;
+
+    public SectionSeatCountResponse(String sectionCode, Long seatCount) {
+        this.sectionCode = sectionCode;
+        this.seatCount = seatCount;
+    }
+}

--- a/src/main/java/com/example/ticketable/domain/stadium/dto/response/SectionTypeSeatCountResponse.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/dto/response/SectionTypeSeatCountResponse.java
@@ -1,0 +1,15 @@
+package com.example.ticketable.domain.stadium.dto.response;
+
+
+import lombok.Getter;
+
+@Getter
+public class SectionTypeSeatCountResponse {
+    private final String sectionType;
+    private final Long seatCount;
+
+    public SectionTypeSeatCountResponse(String sectionType, Long seatCount) {
+        this.sectionType = sectionType;
+        this.seatCount = seatCount;
+    }
+}

--- a/src/main/java/com/example/ticketable/domain/stadium/dto/response/SectionUpdateResponse.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/dto/response/SectionUpdateResponse.java
@@ -1,0 +1,32 @@
+package com.example.ticketable.domain.stadium.dto.response;
+
+import com.example.ticketable.domain.stadium.entity.Section;
+import lombok.Getter;
+
+@Getter
+public class SectionUpdateResponse {
+    private final Long id;
+
+    private final String type;
+
+    private final String code;
+
+    private final Integer extraCharge;
+
+
+    public SectionUpdateResponse(Long id, String type, String code, Integer extraCharge) {
+        this.id = id;
+        this.type = type;
+        this.code = code;
+        this.extraCharge = extraCharge;
+    }
+
+    public static SectionUpdateResponse of(Section section) {
+        return new SectionUpdateResponse(
+                section.getId(),
+                section.getType(),
+                section.getCode(),
+                section.getExtraCharge()
+        );
+    }
+}

--- a/src/main/java/com/example/ticketable/domain/stadium/dto/response/StadiumCreateResponse.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/dto/response/StadiumCreateResponse.java
@@ -1,0 +1,31 @@
+package com.example.ticketable.domain.stadium.dto.response;
+
+import com.example.ticketable.domain.stadium.entity.Stadium;
+import lombok.Getter;
+
+@Getter
+public class StadiumCreateResponse {
+    private final Long id;
+
+    private final String name;
+
+    private final String location;
+
+    private final Integer capacity;
+
+    public StadiumCreateResponse(Long id, String name, String location, Integer capacity) {
+        this.id = id;
+        this.name = name;
+        this.location = location;
+        this.capacity = capacity;
+    }
+
+    public static StadiumCreateResponse of(Stadium stadium) {
+        return new StadiumCreateResponse(
+                stadium.getId(),
+                stadium.getName(),
+                stadium.getLocation(),
+                stadium.getCapacity()
+        );
+    }
+}

--- a/src/main/java/com/example/ticketable/domain/stadium/dto/response/StadiumGetResponse.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/dto/response/StadiumGetResponse.java
@@ -1,0 +1,31 @@
+package com.example.ticketable.domain.stadium.dto.response;
+
+import com.example.ticketable.domain.stadium.entity.Stadium;
+import lombok.Getter;
+
+@Getter
+public class StadiumGetResponse {
+    private final Long id;
+
+    private final String name;
+
+    private final String location;
+
+    private final Integer capacity;
+
+    public StadiumGetResponse(Long id, String name, String location, Integer capacity) {
+        this.id = id;
+        this.name = name;
+        this.location = location;
+        this.capacity = capacity;
+    }
+
+    public static StadiumGetResponse of(Stadium stadium) {
+        return new StadiumGetResponse(
+                stadium.getId(),
+                stadium.getName(),
+                stadium.getLocation(),
+                stadium.getCapacity()
+        );
+    }
+}

--- a/src/main/java/com/example/ticketable/domain/stadium/dto/response/StadiumGetResponse.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/dto/response/StadiumGetResponse.java
@@ -3,33 +3,31 @@ package com.example.ticketable.domain.stadium.dto.response;
 import com.example.ticketable.domain.stadium.entity.Stadium;
 import lombok.Getter;
 
+import java.util.List;
+
 @Getter
 public class StadiumGetResponse {
     private final Long id;
 
     private final String name;
 
-    private final String location;
-
-    private final Integer capacity;
-
     private final String imagePath;
 
-    public StadiumGetResponse(Long id, String name, String location, Integer capacity, String imagePath) {
+    private List<SectionTypeSeatCountResponse> sectionSeatCounts;
+
+    public StadiumGetResponse(Long id, String name, String imagePath, List<SectionTypeSeatCountResponse> sectionSeatCounts) {
         this.id = id;
         this.name = name;
-        this.location = location;
-        this.capacity = capacity;
         this.imagePath = imagePath;
+        this.sectionSeatCounts = sectionSeatCounts;
     }
 
-    public static StadiumGetResponse of(Stadium stadium) {
+    public static StadiumGetResponse of(Stadium stadium, List<SectionTypeSeatCountResponse> sectionSeatCounts) {
         return new StadiumGetResponse(
                 stadium.getId(),
                 stadium.getName(),
-                stadium.getLocation(),
-                stadium.getCapacity(),
-                stadium.getImagePath()
+                stadium.getImagePath(),
+                sectionSeatCounts
         );
     }
 }

--- a/src/main/java/com/example/ticketable/domain/stadium/dto/response/StadiumGetResponse.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/dto/response/StadiumGetResponse.java
@@ -13,11 +13,14 @@ public class StadiumGetResponse {
 
     private final Integer capacity;
 
-    public StadiumGetResponse(Long id, String name, String location, Integer capacity) {
+    private final String imagePath;
+
+    public StadiumGetResponse(Long id, String name, String location, Integer capacity, String imagePath) {
         this.id = id;
         this.name = name;
         this.location = location;
         this.capacity = capacity;
+        this.imagePath = imagePath;
     }
 
     public static StadiumGetResponse of(Stadium stadium) {
@@ -25,7 +28,8 @@ public class StadiumGetResponse {
                 stadium.getId(),
                 stadium.getName(),
                 stadium.getLocation(),
-                stadium.getCapacity()
+                stadium.getCapacity(),
+                stadium.getImagePath()
         );
     }
 }

--- a/src/main/java/com/example/ticketable/domain/stadium/dto/response/StadiumUpdateResponse.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/dto/response/StadiumUpdateResponse.java
@@ -4,7 +4,7 @@ import com.example.ticketable.domain.stadium.entity.Stadium;
 import lombok.Getter;
 
 @Getter
-public class StadiumCreateResponse {
+public class StadiumUpdateResponse {
     private final Long id;
 
     private final String name;
@@ -15,7 +15,7 @@ public class StadiumCreateResponse {
 
     private final String imagePath;
 
-    public StadiumCreateResponse(Long id, String name, String location, Integer capacity, String imagePath) {
+    public StadiumUpdateResponse(Long id, String name, String location, Integer capacity, String imagePath) {
         this.id = id;
         this.name = name;
         this.location = location;
@@ -23,8 +23,8 @@ public class StadiumCreateResponse {
         this.imagePath = imagePath;
     }
 
-    public static StadiumCreateResponse of(Stadium stadium) {
-        return new StadiumCreateResponse(
+    public static StadiumUpdateResponse of(Stadium stadium) {
+        return new StadiumUpdateResponse(
                 stadium.getId(),
                 stadium.getName(),
                 stadium.getLocation(),

--- a/src/main/java/com/example/ticketable/domain/stadium/entity/Seat.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/entity/Seat.java
@@ -17,10 +17,7 @@ public class Seat {
 	private Long id;
 
 	@Column(length = 20)
-	private String rowNum;
-
-	@Column(length = 20)
-	private String colNum;
+	private String position;
 
 	private boolean isBlind;
 	
@@ -31,9 +28,8 @@ public class Seat {
 	private LocalDateTime deletedAt;
 
 	@Builder
-	public Seat(String rowNum, String colNum, boolean isBlind, Section section) {
-		this.rowNum = rowNum;
-		this.colNum = colNum;
+	public Seat(String position, boolean isBlind, Section section) {
+		this.position = position;
 		this.isBlind = isBlind;
 		this.section = section;
 		this.deletedAt = null;

--- a/src/main/java/com/example/ticketable/domain/stadium/entity/Seat.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/entity/Seat.java
@@ -5,12 +5,14 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDateTime;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
+@SQLRestriction("deleted_at is null")
 public class Seat {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -33,5 +35,13 @@ public class Seat {
 		this.isBlind = isBlind;
 		this.section = section;
 		this.deletedAt = null;
+	}
+
+	public void updateBlind() {
+		this.isBlind = !isBlind;
+	}
+
+	public void delete() {
+		this.deletedAt = LocalDateTime.now();
 	}
 }

--- a/src/main/java/com/example/ticketable/domain/stadium/entity/Seat.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/entity/Seat.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
@@ -26,11 +28,14 @@ public class Seat {
 	@JoinColumn(name = "section_id", nullable = false)
 	private Section section;
 
+	private LocalDateTime deletedAt;
+
 	@Builder
 	public Seat(String rowNum, String colNum, boolean isBlind, Section section) {
 		this.rowNum = rowNum;
 		this.colNum = colNum;
 		this.isBlind = isBlind;
 		this.section = section;
+		this.deletedAt = null;
 	}
 }

--- a/src/main/java/com/example/ticketable/domain/stadium/entity/Section.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/entity/Section.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
@@ -25,6 +27,8 @@ public class Section {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "stadium_id", nullable = false)
 	private Stadium stadium;
+
+	private LocalDateTime deletedAt;
 	
 	@Builder
 	public Section(String type, String code, Integer extraCharge, Stadium stadium) {
@@ -32,5 +36,6 @@ public class Section {
 		this.code = code;
 		this.extraCharge = extraCharge;
 		this.stadium = stadium;
+		this.deletedAt = null;
 	}
 }

--- a/src/main/java/com/example/ticketable/domain/stadium/entity/Section.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/entity/Section.java
@@ -5,12 +5,14 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDateTime;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
+@SQLRestriction("deleted_at is null")
 public class Section {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/ticketable/domain/stadium/entity/Section.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/entity/Section.java
@@ -38,4 +38,20 @@ public class Section {
 		this.stadium = stadium;
 		this.deletedAt = null;
 	}
+
+	public void updateType(String type) {
+		this.type = type;
+	}
+
+	public void updateCode(String code) {
+		this.code = code;
+	}
+
+	public void updateExtraChange(Integer extraCharge) {
+		this.extraCharge = extraCharge;
+	}
+
+	public void delete() {
+		this.deletedAt = LocalDateTime.now();
+	}
 }

--- a/src/main/java/com/example/ticketable/domain/stadium/entity/Stadium.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/entity/Stadium.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
@@ -21,11 +23,14 @@ public class Stadium {
 	private String location;
 
 	private Integer capacity;
+
+	private LocalDateTime deletedAt;
 	
 	@Builder
 	public Stadium(String name, String location, Integer capacity) {
 		this.name = name;
 		this.location = location;
 		this.capacity = capacity;
+		this.deletedAt = null;
 	}
 }

--- a/src/main/java/com/example/ticketable/domain/stadium/entity/Stadium.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/entity/Stadium.java
@@ -24,13 +24,30 @@ public class Stadium {
 
 	private Integer capacity;
 
+	private String imagePath;
+
 	private LocalDateTime deletedAt;
+
+
 	
 	@Builder
-	public Stadium(String name, String location, Integer capacity) {
+	public Stadium(String name, String location, Integer capacity, String imagePath) {
 		this.name = name;
 		this.location = location;
 		this.capacity = capacity;
+		this.imagePath = imagePath;
 		this.deletedAt = null;
+	}
+
+	public void updateName(String name) {
+		this.name = name;
+	}
+
+	public void delete() {
+		this.deletedAt = LocalDateTime.now();
+	}
+
+	public void updateImagePath(String imagePath) {
+		this.imagePath = imagePath;
 	}
 }

--- a/src/main/java/com/example/ticketable/domain/stadium/entity/Stadium.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/entity/Stadium.java
@@ -5,12 +5,14 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDateTime;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
+@SQLRestriction("deleted_at is null")
 public class Stadium {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -49,5 +51,9 @@ public class Stadium {
 
 	public void updateImagePath(String imagePath) {
 		this.imagePath = imagePath;
+	}
+
+	public void updateCapacity(int sum) {
+		this.capacity = capacity + sum;
 	}
 }

--- a/src/main/java/com/example/ticketable/domain/stadium/repository/SeatRepository.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/repository/SeatRepository.java
@@ -12,10 +12,12 @@ public interface SeatRepository extends JpaRepository<Seat, Long> {
     @Query("SELECT s FROM Seat s " +
             "LEFT JOIN TicketSeat  ts ON s.id = ts.seat.id " +
             "LEFT JOIN Ticket t ON ts.ticket.id = t.id " +
-            "WHERE s.section = :sectionId " +
+            "WHERE s.section.id = :sectionId " +
             "AND (t.deletedAt IS NOT NULL " +
             "OR ts IS NULL)")
     List<Seat> findUnbookSeatsBySectionId(Long sectionId);
 
     List<Seat> findBySectionId(Long sectionId);
+
+    boolean existsBySectionId(Long sectionId);
 }

--- a/src/main/java/com/example/ticketable/domain/stadium/repository/SeatRepository.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/repository/SeatRepository.java
@@ -11,10 +11,10 @@ public interface SeatRepository extends JpaRepository<Seat, Long> {
 
     @Query("SELECT s FROM Seat s " +
             "LEFT JOIN TicketSeat  ts ON s.id = ts.seat.id " +
-            "LEFT JOIN Ticket t ON ts.ticket.id = t.id " +
+            "LEFT JOIN Ticket t ON ts.ticket.id = t.id AND t.deletedAt IS NOT NULL " +
             "WHERE s.section.id = :sectionId " +
-            "AND (t.deletedAt IS NOT NULL " +
-            "OR ts IS NULL)")
+            "AND ts IS NULL"
+            )
     List<Seat> findUnbookSeatsBySectionId(Long sectionId);
 
     List<Seat> findBySectionId(Long sectionId);

--- a/src/main/java/com/example/ticketable/domain/stadium/repository/SeatRepository.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/repository/SeatRepository.java
@@ -3,7 +3,19 @@ package com.example.ticketable.domain.stadium.repository;
 
 import com.example.ticketable.domain.stadium.entity.Seat;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface SeatRepository extends JpaRepository<Seat, Long> {
 
+    @Query("SELECT s FROM Seat s " +
+            "LEFT JOIN TicketSeat  ts ON s.id = ts.seat.id " +
+            "LEFT JOIN Ticket t ON ts.ticket.id = t.id " +
+            "WHERE s.section = :sectionId " +
+            "AND (t.deletedAt IS NOT NULL " +
+            "OR ts IS NULL)")
+    List<Seat> findUnbookSeatsBySectionId(Long sectionId);
+
+    List<Seat> findBySectionId(Long sectionId);
 }

--- a/src/main/java/com/example/ticketable/domain/stadium/repository/SectionRepository.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/repository/SectionRepository.java
@@ -1,9 +1,27 @@
 package com.example.ticketable.domain.stadium.repository;
 
 
+import com.example.ticketable.domain.stadium.dto.response.SectionSeatCountResponse;
+import com.example.ticketable.domain.stadium.dto.response.SectionTypeSeatCountResponse;
 import com.example.ticketable.domain.stadium.entity.Section;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface SectionRepository extends JpaRepository<Section, Long> {
 
+        @Query("SELECT new com.example.ticketable.domain.stadium.dto.response.SectionSeatCountResponse( " +
+            "sn.code, COUNT(st.id)) " +
+            "FROM Section sn " +
+            "JOIN Seat st ON sn.id = st.section.id " +
+            "LEFT JOIN TicketSeat ts ON st.id = ts.seat.id " +
+            "WHERE sn.stadium.id = :stadiumId " +
+            "AND ts.id IS NULL " +
+            "GROUP BY sn.code, sn.type " +
+            "HAVING sn.type = :type"
+        )
+        List<SectionSeatCountResponse> findSectionSeatCountsBySectionId(@Param("stadiumId") Long stadiumId, @Param("type") String type);
 }
+

--- a/src/main/java/com/example/ticketable/domain/stadium/repository/StadiumRepository.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/repository/StadiumRepository.java
@@ -1,9 +1,24 @@
 package com.example.ticketable.domain.stadium.repository;
 
 
+import com.example.ticketable.domain.stadium.dto.response.SectionTypeSeatCountResponse;
 import com.example.ticketable.domain.stadium.entity.Stadium;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface StadiumRepository extends JpaRepository<Stadium, Long> {
+
+    @Query("SELECT new com.example.ticketable.domain.stadium.dto.response.SectionTypeSeatCountResponse( " +
+            "sn.type, COUNT(st.id)) " +
+            "FROM Section sn " +
+            "JOIN Seat st ON sn.id = st.section.id " +
+            "LEFT JOIN TicketSeat ts ON st.id = ts.seat.id " +
+            "WHERE sn.stadium.id = :stadiumId " +
+            "AND ts.id IS NULL " +
+            "GROUP BY sn.type")
+    List<SectionTypeSeatCountResponse> findSectionTypeAndSeatCountsByStadiumId(@Param("stadiumId") Long stadiumId);
 
 }

--- a/src/main/java/com/example/ticketable/domain/stadium/service/SeatService.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/service/SeatService.java
@@ -4,4 +4,6 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class SeatService {
+    // CRUD
+    // PRICE
 }

--- a/src/main/java/com/example/ticketable/domain/stadium/service/SeatService.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/service/SeatService.java
@@ -1,9 +1,78 @@
 package com.example.ticketable.domain.stadium.service;
 
+import com.example.ticketable.common.exception.ErrorCode;
+import com.example.ticketable.common.exception.ServerException;
+import com.example.ticketable.domain.stadium.dto.request.SeatCreateRequest;
+import com.example.ticketable.domain.stadium.dto.response.SeatCreateResponse;
+import com.example.ticketable.domain.stadium.dto.response.SeatGetResponse;
+import com.example.ticketable.domain.stadium.entity.Seat;
+import com.example.ticketable.domain.stadium.entity.Section;
+import com.example.ticketable.domain.stadium.repository.SeatRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 @Service
+@RequiredArgsConstructor
 public class SeatService {
     // CRUD
+    private final SeatRepository seatRepository;
+
+    private final SectionService sectionService;
+
+    public List<SeatCreateResponse> createSeats(Long sectionId, SeatCreateRequest request) {
+        Section section = sectionService.getById(sectionId);
+
+        List<List<String>> colNums = request.getColNums();
+        List<List<Boolean>> isBlind = request.getIsBlind();;
+
+        // 일관성 검사
+        if (colNums.size() != isBlind.size()) {
+            throw new ServerException(ErrorCode.COLUMN_NUMS_AND_BLIND_STATUS_NOT_SAME_SIZE);
+        }
+        for (int i = 0; i < colNums.size(); i++) {
+            if (colNums.get(i).size() != isBlind.get(i).size()) {
+                throw new ServerException(ErrorCode.COLUMN_NUMS_AND_BLIND_STATUS_NOT_SAME_SIZE);
+            }
+        }
+        List<SeatCreateResponse> seatList = new ArrayList<>();
+        for (int i = 1; i <= colNums.size(); i++) {
+            for (int j = 0; j < colNums.get(i-1).size(); j++) {
+                Seat seat = seatRepository.save(
+                        Seat.builder()
+                                .position(i+"열 "+ colNums.get(i-1).get(j))
+                                .isBlind(isBlind.get(i-1).get(j))
+                                .section(section)
+                                .build()
+                );
+                seatList.add(SeatCreateResponse.of(seat));
+            }
+        }
+        return seatList;
+    }
+
+    public List<SeatGetResponse> getSeats(Long sectionId) {
+        List<Seat> seatList = seatRepository.findBySectionId(sectionId);
+        List<Seat> unbookSeatList = seatRepository.findUnbookSeatsBySectionId(sectionId);
+
+        Set<Long> unbookedSeatIds = new HashSet<>();
+        for (Seat seat : unbookSeatList) {
+                unbookedSeatIds.add(seat.getId());
+        }
+
+        List<SeatGetResponse> responseList = new ArrayList<>();
+        for (Seat seat : seatList) {
+            boolean isBooked = !unbookedSeatIds.contains(seat.getId());
+            SeatGetResponse response = SeatGetResponse.of(seat, isBooked);
+            responseList.add(response);
+        }
+        return responseList;
+    }
+
     // PRICE
 }

--- a/src/main/java/com/example/ticketable/domain/stadium/service/SectionService.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/service/SectionService.java
@@ -49,4 +49,8 @@ public class SectionService {
 
         section.delete();
     }
+
+    public Section getById(Long sectionId) {
+        return sectionRepository.findById(sectionId).orElseThrow(() -> new ServerException(ErrorCode.SECTION_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/example/ticketable/domain/stadium/service/SectionService.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/service/SectionService.java
@@ -1,7 +1,52 @@
 package com.example.ticketable.domain.stadium.service;
 
+import com.example.ticketable.common.exception.ErrorCode;
+import com.example.ticketable.common.exception.ServerException;
+import com.example.ticketable.domain.stadium.dto.request.SectionCreateRequest;
+import com.example.ticketable.domain.stadium.dto.request.SectionUpdateRequest;
+import com.example.ticketable.domain.stadium.dto.response.SectionCreateResponse;
+import com.example.ticketable.domain.stadium.dto.response.SectionUpdateResponse;
+import com.example.ticketable.domain.stadium.entity.Section;
+import com.example.ticketable.domain.stadium.entity.Stadium;
+import com.example.ticketable.domain.stadium.repository.SectionRepository;
+import lombok.RequiredArgsConstructor;
+import org.apache.catalina.Server;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class SectionService {
+    private final SectionRepository sectionRepository;
+
+    private final StadiumService stadiumService;
+
+    public SectionCreateResponse createSection(Long stadiumId, SectionCreateRequest request) {
+        Stadium stadium = stadiumService.getStadium(stadiumId);
+
+        Section section = sectionRepository.save(
+                Section.builder()
+                        .type(request.getType())
+                        .code(request.getCode())
+                        .extraCharge(request.getExtraCharge())
+                        .stadium(stadium)
+                        .build()
+        );
+        return SectionCreateResponse.of(section);
+    }
+
+    public SectionUpdateResponse updateSection(Long sectionId, SectionUpdateRequest request) {
+        Section section = sectionRepository.findById(sectionId).orElseThrow(() -> new ServerException(ErrorCode.SECTION_NOT_FOUND));
+
+        section.updateType(request.getType());
+        section.updateCode(request.getCode());
+        section.updateExtraChange(request.getExtraCharge());
+
+        return SectionUpdateResponse.of(section);
+    }
+
+    public void delete(Long sectionId) {
+        Section section = sectionRepository.findById(sectionId).orElseThrow(() -> new ServerException(ErrorCode.SECTION_NOT_FOUND));
+
+        section.delete();
+    }
 }

--- a/src/main/java/com/example/ticketable/domain/stadium/service/SectionService.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/service/SectionService.java
@@ -41,7 +41,7 @@ public class SectionService {
 
     @Transactional
     public SectionUpdateResponse updateSection(Long sectionId, SectionUpdateRequest request) {
-        Section section = sectionRepository.findById(sectionId).orElseThrow(() -> new ServerException(ErrorCode.SECTION_NOT_FOUND));
+        Section section = getById(sectionId);
 
         section.updateType(request.getType());
         section.updateCode(request.getCode());
@@ -52,7 +52,7 @@ public class SectionService {
 
     @Transactional
     public void delete(Long sectionId) {
-        Section section = sectionRepository.findById(sectionId).orElseThrow(() -> new ServerException(ErrorCode.SECTION_NOT_FOUND));
+        Section section = getById(sectionId);
         section.delete();
     }
 

--- a/src/main/java/com/example/ticketable/domain/stadium/service/SectionService.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/service/SectionService.java
@@ -5,6 +5,7 @@ import com.example.ticketable.common.exception.ServerException;
 import com.example.ticketable.domain.stadium.dto.request.SectionCreateRequest;
 import com.example.ticketable.domain.stadium.dto.request.SectionUpdateRequest;
 import com.example.ticketable.domain.stadium.dto.response.SectionCreateResponse;
+import com.example.ticketable.domain.stadium.dto.response.SectionSeatCountResponse;
 import com.example.ticketable.domain.stadium.dto.response.SectionUpdateResponse;
 import com.example.ticketable.domain.stadium.entity.Section;
 import com.example.ticketable.domain.stadium.entity.Stadium;
@@ -12,6 +13,9 @@ import com.example.ticketable.domain.stadium.repository.SectionRepository;
 import lombok.RequiredArgsConstructor;
 import org.apache.catalina.Server;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -20,6 +24,7 @@ public class SectionService {
 
     private final StadiumService stadiumService;
 
+    @Transactional
     public SectionCreateResponse createSection(Long stadiumId, SectionCreateRequest request) {
         Stadium stadium = stadiumService.getStadium(stadiumId);
 
@@ -34,6 +39,7 @@ public class SectionService {
         return SectionCreateResponse.of(section);
     }
 
+    @Transactional
     public SectionUpdateResponse updateSection(Long sectionId, SectionUpdateRequest request) {
         Section section = sectionRepository.findById(sectionId).orElseThrow(() -> new ServerException(ErrorCode.SECTION_NOT_FOUND));
 
@@ -44,13 +50,17 @@ public class SectionService {
         return SectionUpdateResponse.of(section);
     }
 
+    @Transactional
     public void delete(Long sectionId) {
         Section section = sectionRepository.findById(sectionId).orElseThrow(() -> new ServerException(ErrorCode.SECTION_NOT_FOUND));
-
         section.delete();
     }
 
     public Section getById(Long sectionId) {
         return sectionRepository.findById(sectionId).orElseThrow(() -> new ServerException(ErrorCode.SECTION_NOT_FOUND));
+    }
+
+    public List<SectionSeatCountResponse> getAvailableSeatsBySectionCode(Long stadiumId, String type) {
+        return sectionRepository.findSectionSeatCountsBySectionId(stadiumId, type);
     }
 }

--- a/src/main/java/com/example/ticketable/domain/stadium/service/StadiumService.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/service/StadiumService.java
@@ -1,15 +1,16 @@
 package com.example.ticketable.domain.stadium.service;
 
 import com.example.ticketable.common.exception.ErrorCode;
+import com.example.ticketable.common.exception.ServerException;
 import com.example.ticketable.domain.stadium.dto.request.StadiumCreateRequest;
+import com.example.ticketable.domain.stadium.dto.request.StadiumUpdateRequest;
 import com.example.ticketable.domain.stadium.dto.response.StadiumCreateResponse;
 import com.example.ticketable.domain.stadium.dto.response.StadiumGetResponse;
+import com.example.ticketable.domain.stadium.dto.response.StadiumUpdateResponse;
 import com.example.ticketable.domain.stadium.entity.Stadium;
 import com.example.ticketable.domain.stadium.repository.StadiumRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import java.rmi.ServerException;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +23,7 @@ public class StadiumService {
                         .name(request.getName())
                         .location(request.getLocation())
                         .capacity(0)
+                        .imagePath("이미지 주소")
                         .build()
         );
         return StadiumCreateResponse.of(stadium);
@@ -30,5 +32,23 @@ public class StadiumService {
 
     public StadiumGetResponse getStadium(Long stadiumId) {
         Stadium stadium = stadiumRepository.findById(stadiumId).orElseThrow(()-> new ServerException(ErrorCode.STADIUM_NOT_FOUND));
+
+        // 좌석 정보 추가 예정
+        return StadiumGetResponse.of(stadium);
+    }
+
+
+    public StadiumUpdateResponse updateStadium(Long stadiumId, StadiumUpdateRequest request) {
+        Stadium stadium = stadiumRepository.findById(stadiumId).orElseThrow(()-> new ServerException(ErrorCode.STADIUM_NOT_FOUND));
+
+        stadium.updateName(request.getName());
+        stadium.updateImagePath("새로운 이미지 경로");
+
+        return StadiumUpdateResponse.of(stadium);
+    }
+
+    public void deleteStadium(Long stadiumId) {
+        Stadium stadium = stadiumRepository.findById(stadiumId).orElseThrow(()-> new ServerException(ErrorCode.STADIUM_NOT_FOUND));
+        stadium.delete();
     }
 }

--- a/src/main/java/com/example/ticketable/domain/stadium/service/StadiumService.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/service/StadiumService.java
@@ -36,7 +36,7 @@ public class StadiumService {
 
 
     public StadiumGetResponse getStadiumDto(Long stadiumId) {
-        Stadium stadium = stadiumRepository.findById(stadiumId).orElseThrow(()-> new ServerException(ErrorCode.STADIUM_NOT_FOUND));
+        Stadium stadium = getStadium(stadiumId);
         List<SectionTypeSeatCountResponse> sectionSeatCounts = stadiumRepository.findSectionTypeAndSeatCountsByStadiumId(stadiumId);
 
         return StadiumGetResponse.of(stadium, sectionSeatCounts);
@@ -44,7 +44,7 @@ public class StadiumService {
 
     @Transactional
     public StadiumUpdateResponse updateStadium(Long stadiumId, StadiumUpdateRequest request) {
-        Stadium stadium = stadiumRepository.findById(stadiumId).orElseThrow(()-> new ServerException(ErrorCode.STADIUM_NOT_FOUND));
+        Stadium stadium = getStadium(stadiumId);
 
         stadium.updateName(request.getName());
         stadium.updateImagePath("새로운 이미지 경로");
@@ -54,7 +54,7 @@ public class StadiumService {
 
     @Transactional
     public void deleteStadium(Long stadiumId) {
-        Stadium stadium = stadiumRepository.findById(stadiumId).orElseThrow(()-> new ServerException(ErrorCode.STADIUM_NOT_FOUND));
+        Stadium stadium = getStadium(stadiumId);
         stadium.delete();
     }
 

--- a/src/main/java/com/example/ticketable/domain/stadium/service/StadiumService.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/service/StadiumService.java
@@ -1,7 +1,34 @@
 package com.example.ticketable.domain.stadium.service;
 
+import com.example.ticketable.common.exception.ErrorCode;
+import com.example.ticketable.domain.stadium.dto.request.StadiumCreateRequest;
+import com.example.ticketable.domain.stadium.dto.response.StadiumCreateResponse;
+import com.example.ticketable.domain.stadium.dto.response.StadiumGetResponse;
+import com.example.ticketable.domain.stadium.entity.Stadium;
+import com.example.ticketable.domain.stadium.repository.StadiumRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.rmi.ServerException;
+
 @Service
+@RequiredArgsConstructor
 public class StadiumService {
+    private final StadiumRepository stadiumRepository;
+
+    public StadiumCreateResponse createStadium(StadiumCreateRequest request) {
+        Stadium stadium = stadiumRepository.save(
+                Stadium.builder()
+                        .name(request.getName())
+                        .location(request.getLocation())
+                        .capacity(0)
+                        .build()
+        );
+        return StadiumCreateResponse.of(stadium);
+    }
+
+
+    public StadiumGetResponse getStadium(Long stadiumId) {
+        Stadium stadium = stadiumRepository.findById(stadiumId).orElseThrow(()-> new ServerException(ErrorCode.STADIUM_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/example/ticketable/domain/stadium/service/StadiumService.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/service/StadiumService.java
@@ -4,6 +4,7 @@ import com.example.ticketable.common.exception.ErrorCode;
 import com.example.ticketable.common.exception.ServerException;
 import com.example.ticketable.domain.stadium.dto.request.StadiumCreateRequest;
 import com.example.ticketable.domain.stadium.dto.request.StadiumUpdateRequest;
+import com.example.ticketable.domain.stadium.dto.response.SectionTypeSeatCountResponse;
 import com.example.ticketable.domain.stadium.dto.response.StadiumCreateResponse;
 import com.example.ticketable.domain.stadium.dto.response.StadiumGetResponse;
 import com.example.ticketable.domain.stadium.dto.response.StadiumUpdateResponse;
@@ -11,12 +12,16 @@ import com.example.ticketable.domain.stadium.entity.Stadium;
 import com.example.ticketable.domain.stadium.repository.StadiumRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class StadiumService {
     private final StadiumRepository stadiumRepository;
 
+    @Transactional
     public StadiumCreateResponse createStadium(StadiumCreateRequest request) {
         Stadium stadium = stadiumRepository.save(
                 Stadium.builder()
@@ -32,11 +37,12 @@ public class StadiumService {
 
     public StadiumGetResponse getStadiumDto(Long stadiumId) {
         Stadium stadium = stadiumRepository.findById(stadiumId).orElseThrow(()-> new ServerException(ErrorCode.STADIUM_NOT_FOUND));
+        List<SectionTypeSeatCountResponse> sectionSeatCounts = stadiumRepository.findSectionTypeAndSeatCountsByStadiumId(stadiumId);
 
-        // 좌석 정보 추가 예정
-        return StadiumGetResponse.of(stadium);
+        return StadiumGetResponse.of(stadium, sectionSeatCounts);
     }
 
+    @Transactional
     public StadiumUpdateResponse updateStadium(Long stadiumId, StadiumUpdateRequest request) {
         Stadium stadium = stadiumRepository.findById(stadiumId).orElseThrow(()-> new ServerException(ErrorCode.STADIUM_NOT_FOUND));
 
@@ -46,6 +52,7 @@ public class StadiumService {
         return StadiumUpdateResponse.of(stadium);
     }
 
+    @Transactional
     public void deleteStadium(Long stadiumId) {
         Stadium stadium = stadiumRepository.findById(stadiumId).orElseThrow(()-> new ServerException(ErrorCode.STADIUM_NOT_FOUND));
         stadium.delete();

--- a/src/main/java/com/example/ticketable/domain/stadium/service/StadiumService.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/service/StadiumService.java
@@ -30,13 +30,12 @@ public class StadiumService {
     }
 
 
-    public StadiumGetResponse getStadium(Long stadiumId) {
+    public StadiumGetResponse getStadiumDto(Long stadiumId) {
         Stadium stadium = stadiumRepository.findById(stadiumId).orElseThrow(()-> new ServerException(ErrorCode.STADIUM_NOT_FOUND));
 
         // 좌석 정보 추가 예정
         return StadiumGetResponse.of(stadium);
     }
-
 
     public StadiumUpdateResponse updateStadium(Long stadiumId, StadiumUpdateRequest request) {
         Stadium stadium = stadiumRepository.findById(stadiumId).orElseThrow(()-> new ServerException(ErrorCode.STADIUM_NOT_FOUND));
@@ -50,5 +49,9 @@ public class StadiumService {
     public void deleteStadium(Long stadiumId) {
         Stadium stadium = stadiumRepository.findById(stadiumId).orElseThrow(()-> new ServerException(ErrorCode.STADIUM_NOT_FOUND));
         stadium.delete();
+    }
+
+    public Stadium getStadium(Long stadiumId) {
+         return stadiumRepository.findById(stadiumId).orElseThrow(()-> new ServerException(ErrorCode.STADIUM_NOT_FOUND));
     }
 }

--- a/src/main/java/com/example/ticketable/domain/ticket/entity/Ticket.java
+++ b/src/main/java/com/example/ticketable/domain/ticket/entity/Ticket.java
@@ -9,6 +9,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
@@ -25,6 +27,8 @@ public class Ticket {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "game_id", nullable = false)
 	private Game game;
+
+	private LocalDateTime deletedAt;
 
 	@Builder
 	public Ticket(Member member, Game game) {


### PR DESCRIPTION
## 📌 PR 요약
- 경기장 CRUD
- 구역 CRUD
- 좌석 CRUD

## 🔗 관련 이슈
- 관련된 이슈 번호를 연결해주세요.
    - closed #5 
    - closed #6 
    - closed #9 

## 🛠️ 변경 사항
- 주요 변경 사항을 bullet으로 작성해주세요.
    - 경기장 관련 CRUD 3가지 구현
    - 구역 타입, 코드 별 남은 좌석을 보여주는 기능 구현
    - 좌석 생성 시 한번에 한 구역의 모든 좌석을 생성하도록 구현



| 기능 | 스크린샷 |
| --- | --- |
| 경기장 생성 | ![image](https://github.com/user-attachments/assets/8b89c831-37f2-439f-b46c-dba6b480c3e4) |
| 경기장 조회 & 구역 타입 별 남은 좌석 조회 | ![image](https://github.com/user-attachments/assets/f7c06af8-39c7-41f0-908c-c394b927c240) |
| 구역 생성 | ![image](https://github.com/user-attachments/assets/4867a9d4-75a7-440f-a807-584d6560b841) |
| 특정 구역 타입의 담은 좌석 조회 | ![image](https://github.com/user-attachments/assets/cbddf202-bc9d-4133-82a8-088b817641d9) |
| 좌석 생성 | ![image](https://github.com/user-attachments/assets/fbded089-3981-4293-946e-077638c5eb91) |
| 좌석 조회 | ![image](https://github.com/user-attachments/assets/3926bbbf-02d3-4b95-94f3-a9a53576c1dd) |

## ⚠️ 주의 사항 (선택)
한 구역에 대한 좌석 생성은 한번에 진행해야 합니다!
현재 쿼리에 경기 관련된 사항은 들어가 있지 않습니다 경기 CRUD 구현 한 뒤 추가하도록 하겠습니다

## ✅ 체크리스트
PR 작성자가 확인해야 할 항목입니다:
- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] 코드 리뷰어를 등록했습니다.
- [x] Labels를 등록했습니다.