### PR TITLE
✨ Feat: 경기 CRUD 및 조회 쿼리에 경기 정보 추가

### DIFF
--- a/src/main/java/com/example/ticketable/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/ticketable/common/exception/ErrorCode.java
@@ -19,6 +19,9 @@ public enum ErrorCode {
 	BLIND_STATUS_ALREADY_SET("시야 방해석 상태가 이미 요청된 상태와 동일합니다.", BAD_REQUEST),
 	SEATS_ALREADY_EXISTS("이미 구역에 좌석이 있습니다.", BAD_REQUEST),
 
+	// 경기
+	GAME_NOT_FOUND("해당하는 경기를 찾을 수 없습니다.", NOT_FOUND),
+
 	// 티켓
 	
 	// 경매

--- a/src/main/java/com/example/ticketable/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/ticketable/common/exception/ErrorCode.java
@@ -13,7 +13,9 @@ public enum ErrorCode {
 	
 	// 경기장
 	STADIUM_NOT_FOUND("해당하는 경기장을 찾을 수 없습니다.", NOT_FOUND),
+	STADIUM_NAME_DUPLICATION("다른 경기장과 이름이 중복됩니다.", BAD_REQUEST),
 	SECTION_NOT_FOUND("해당하는 구역을 찾을 수 없습니다.", NOT_FOUND),
+	SECTION_CODE_DUPLICATION("다른 구역과 코드가 중복됩니다.", BAD_REQUEST),
 	SEAT_NOT_FOUND("해당하는 좌석을 찾을 수 없습니다.", NOT_FOUND),
 	COLUMN_NUMS_AND_BLIND_STATUS_NOT_SAME_SIZE("열 번호와 시야 방해 여부 리스트의 크기는 같아야 합니다.", BAD_REQUEST),
 	BLIND_STATUS_ALREADY_SET("시야 방해석 상태가 이미 요청된 상태와 동일합니다.", BAD_REQUEST),

--- a/src/main/java/com/example/ticketable/domain/game/controller/GameController.java
+++ b/src/main/java/com/example/ticketable/domain/game/controller/GameController.java
@@ -1,7 +1,50 @@
 package com.example.ticketable.domain.game.controller;
 
-import org.springframework.web.bind.annotation.RestController;
+import com.example.ticketable.domain.game.dto.request.GameCreateRequest;
+import com.example.ticketable.domain.game.dto.request.GameUpdateRequest;
+import com.example.ticketable.domain.game.dto.response.GameCreateResponse;
+import com.example.ticketable.domain.game.dto.response.GameGetResponse;
+import com.example.ticketable.domain.game.dto.response.GameUpdateResponse;
+import com.example.ticketable.domain.game.service.GameService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
 public class GameController {
+    private final GameService gameService;
+
+    @PostMapping("/v1/games")
+    public ResponseEntity<GameCreateResponse> createGame(@RequestBody GameCreateRequest request) {
+        return ResponseEntity.ok(gameService.createGame(request));
+    }
+
+    @GetMapping("/v1/games")
+    public ResponseEntity<List<GameGetResponse>> getGames(
+            @RequestParam (required = false) String team,
+            @RequestParam (required = false) LocalDateTime date
+            ) {
+        return ResponseEntity.ok(gameService.getGames(team, date));
+    }
+
+    @PutMapping("/v1/games/{gameId}")
+    public ResponseEntity<GameUpdateResponse> updateGame(
+            @PathVariable Long gameId,
+            @RequestBody GameUpdateRequest request
+    ) {
+        return ResponseEntity.ok(gameService.updateGame(gameId, request));
+    }
+
+    @DeleteMapping("/v1/games/{gameId}")
+    public ResponseEntity<Void> deleteGame(@PathVariable Long gameId) {
+        gameService.deleteGames(gameId);
+        return ResponseEntity.ok().build();
+    }
+
+
 }

--- a/src/main/java/com/example/ticketable/domain/game/controller/GameController.java
+++ b/src/main/java/com/example/ticketable/domain/game/controller/GameController.java
@@ -6,6 +6,9 @@ import com.example.ticketable.domain.game.dto.response.GameCreateResponse;
 import com.example.ticketable.domain.game.dto.response.GameGetResponse;
 import com.example.ticketable.domain.game.dto.response.GameUpdateResponse;
 import com.example.ticketable.domain.game.service.GameService;
+import com.example.ticketable.domain.stadium.dto.response.SeatGetResponse;
+import com.example.ticketable.domain.stadium.dto.response.SectionSeatCountResponse;
+import com.example.ticketable.domain.stadium.dto.response.StadiumGetResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -30,6 +33,29 @@ public class GameController {
             @RequestParam (required = false) LocalDateTime date
             ) {
         return ResponseEntity.ok(gameService.getGames(team, date));
+    }
+
+    @GetMapping("/v1/games/{gameId}")
+    public ResponseEntity<StadiumGetResponse> getStadiumAndSectionSeatCounts(
+            @PathVariable Long gameId
+    ) {
+        return ResponseEntity.ok(gameService.getStadiumAndSectionSeatCounts(gameId));
+    }
+
+    @GetMapping("/v1/games/{gameId}/sectionTypes")
+    public ResponseEntity<List<SectionSeatCountResponse>> getAvailableSeatsBySectionType(
+            @PathVariable Long gameId,
+            @RequestParam String type
+    ) {
+        return ResponseEntity.ok(gameService.getAvailableSeatsBySectionType(gameId, type));
+    }
+
+    @GetMapping("/v1/games/{gameId}/sections/{sectionId}")
+    public ResponseEntity<List<SeatGetResponse>> getSeatInfoBySection(
+            @PathVariable Long gameId,
+            @PathVariable Long sectionId
+    ) {
+        return ResponseEntity.ok(gameService.getSeatInfoBySection(sectionId, gameId));
     }
 
     @PutMapping("/v1/games/{gameId}")

--- a/src/main/java/com/example/ticketable/domain/game/dto/request/GameCreateRequest.java
+++ b/src/main/java/com/example/ticketable/domain/game/dto/request/GameCreateRequest.java
@@ -1,0 +1,33 @@
+package com.example.ticketable.domain.game.dto.request;
+
+import com.example.ticketable.domain.game.enums.GameType;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class GameCreateRequest {
+    private Long stadiumId;
+
+    private String away;
+
+    private String home;
+
+    private GameType type;
+
+    private Integer point;
+
+    private String imagePath;
+
+    private LocalDateTime startTime;
+
+    public GameCreateRequest(Long stadiumId, String away, String home, GameType type, Integer point, String imagePath, LocalDateTime startTime) {
+        this.stadiumId = stadiumId;
+        this.away = away;
+        this.home = home;
+        this.type = type;
+        this.point = point;
+        this.imagePath = imagePath;
+        this.startTime = startTime;
+    }
+}

--- a/src/main/java/com/example/ticketable/domain/game/dto/request/GameUpdateRequest.java
+++ b/src/main/java/com/example/ticketable/domain/game/dto/request/GameUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.example.ticketable.domain.game.dto.request;
+
+import com.example.ticketable.domain.game.enums.GameType;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class GameUpdateRequest {
+
+    private LocalDateTime startTime;
+
+    public GameUpdateRequest(LocalDateTime startTime) {
+        this.startTime = startTime;
+    }
+}

--- a/src/main/java/com/example/ticketable/domain/game/dto/response/GameCreateResponse.java
+++ b/src/main/java/com/example/ticketable/domain/game/dto/response/GameCreateResponse.java
@@ -1,0 +1,47 @@
+package com.example.ticketable.domain.game.dto.response;
+
+import com.example.ticketable.domain.game.entity.Game;
+import com.example.ticketable.domain.game.enums.GameType;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class GameCreateResponse {
+    private final Long id;
+
+    private final String away;
+
+    private final String home;
+
+    private final GameType type;
+
+    private final Integer point;
+
+    private final String imagePath;
+
+    private final LocalDateTime startTime;
+
+
+    public GameCreateResponse(Long id, String away, String home, GameType type, Integer point, String imagePath, LocalDateTime startTime) {
+        this.id = id;
+        this.away = away;
+        this.home = home;
+        this.type = type;
+        this.point = point;
+        this.imagePath = imagePath;
+        this.startTime = startTime;
+    }
+
+    public static GameCreateResponse of(Game game) {
+        return new GameCreateResponse(
+                game.getId(),
+                game.getAway(),
+                game.getHome(),
+                game.getType(),
+                game.getPoint(),
+                game.getImagePath(),
+                game.getStartTime()
+        );
+    }
+}

--- a/src/main/java/com/example/ticketable/domain/game/dto/response/GameGetResponse.java
+++ b/src/main/java/com/example/ticketable/domain/game/dto/response/GameGetResponse.java
@@ -1,0 +1,47 @@
+package com.example.ticketable.domain.game.dto.response;
+
+import com.example.ticketable.domain.game.entity.Game;
+import com.example.ticketable.domain.game.enums.GameType;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class GameGetResponse {
+    private final Long id;
+
+    private final String away;
+
+    private final String home;
+
+    private final GameType type;
+
+    private final Integer point;
+
+    private final String imagePath;
+
+    private final LocalDateTime startTime;
+
+
+    public GameGetResponse(Long id, String away, String home, GameType type, Integer point, String imagePath, LocalDateTime startTime) {
+        this.id = id;
+        this.away = away;
+        this.home = home;
+        this.type = type;
+        this.point = point;
+        this.imagePath = imagePath;
+        this.startTime = startTime;
+    }
+
+    public static GameGetResponse of(Game game) {
+        return new GameGetResponse(
+                game.getId(),
+                game.getAway(),
+                game.getHome(),
+                game.getType(),
+                game.getPoint(),
+                game.getImagePath(),
+                game.getStartTime()
+        );
+    }
+}

--- a/src/main/java/com/example/ticketable/domain/game/dto/response/GameUpdateResponse.java
+++ b/src/main/java/com/example/ticketable/domain/game/dto/response/GameUpdateResponse.java
@@ -1,0 +1,47 @@
+package com.example.ticketable.domain.game.dto.response;
+
+import com.example.ticketable.domain.game.entity.Game;
+import com.example.ticketable.domain.game.enums.GameType;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class GameUpdateResponse {
+    private final Long id;
+
+    private final String away;
+
+    private final String home;
+
+    private final GameType type;
+
+    private final Integer point;
+
+    private final String imagePath;
+
+    private final LocalDateTime startTime;
+
+
+    public GameUpdateResponse(Long id, String away, String home, GameType type, Integer point, String imagePath, LocalDateTime startTime) {
+        this.id = id;
+        this.away = away;
+        this.home = home;
+        this.type = type;
+        this.point = point;
+        this.imagePath = imagePath;
+        this.startTime = startTime;
+    }
+
+    public static GameUpdateResponse of(Game game) {
+        return new GameUpdateResponse(
+                game.getId(),
+                game.getAway(),
+                game.getHome(),
+                game.getType(),
+                game.getPoint(),
+                game.getImagePath(),
+                game.getStartTime()
+        );
+    }
+}

--- a/src/main/java/com/example/ticketable/domain/game/entity/Game.java
+++ b/src/main/java/com/example/ticketable/domain/game/entity/Game.java
@@ -1,6 +1,7 @@
 package com.example.ticketable.domain.game.entity;
 
 import com.example.ticketable.domain.game.enums.GameType;
+import com.example.ticketable.domain.stadium.entity.Stadium;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -17,6 +18,10 @@ public class Game {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "stadium_id", nullable = false)
+	private Stadium stadium;
+
 	@Column(length = 50)
 	private String away;
 
@@ -29,14 +34,29 @@ public class Game {
 	
 	private Integer point;
 
+	private String imagePath;
+
 	private LocalDateTime startTime;
+
+	private LocalDateTime deletedAt;
 	
 	@Builder
-	public Game(String away, String home, GameType type, Integer point, LocalDateTime startTime) {
+	public Game(String away, Stadium stadium, String home, GameType type, Integer point, String imagePath, LocalDateTime startTime) {
+		this.stadium = stadium;
 		this.away = away;
 		this.home = home;
 		this.type = type;
 		this.point = point;
+		this.imagePath = imagePath;
+		this.startTime = startTime;
+		this.deletedAt = null;
+	}
+
+	public void cancel() {
+		deletedAt = LocalDateTime.now();
+	}
+
+	public void updateStartTime(LocalDateTime startTime) {
 		this.startTime = startTime;
 	}
 }

--- a/src/main/java/com/example/ticketable/domain/game/repository/GameRepository.java
+++ b/src/main/java/com/example/ticketable/domain/game/repository/GameRepository.java
@@ -2,7 +2,13 @@ package com.example.ticketable.domain.game.repository;
 
 
 import com.example.ticketable.domain.game.entity.Game;
+import com.example.ticketable.domain.stadium.dto.response.SeatGetResponse;
+import com.example.ticketable.domain.stadium.dto.response.SectionSeatCountResponse;
+import com.example.ticketable.domain.stadium.dto.response.SectionTypeSeatCountResponse;
+import com.example.ticketable.domain.stadium.entity.Stadium;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -14,4 +20,75 @@ public interface GameRepository extends JpaRepository<Game, Long> {
     List<Game> findByHome(String home);
 
     List<Game> findByStartTimeBetween(LocalDateTime start, LocalDateTime end);
+
+    @Query("SELECT g.stadium From Game g where g.id = :gameId")
+    Stadium getStadiumByGameId(@Param("gameId") Long gameId);
+
+    @Query("""
+    SELECT new com.example.ticketable.domain.stadium.dto.response.SectionTypeSeatCountResponse(
+        s.type, COUNT(seat))
+    FROM Seat seat
+    JOIN seat.section s
+    JOIN s.stadium st
+    JOIN Game g ON g.stadium.id = st.id
+    WHERE g.id = :gameId
+      AND seat.id NOT IN (
+        SELECT ts.seat.id
+        FROM TicketSeat ts
+        JOIN ts.ticket t
+        WHERE t.game.id = :gameId
+          AND t.deletedAt IS NULL
+      )
+    GROUP BY s.type
+    """)
+    List<SectionTypeSeatCountResponse> findUnBookedSeatsCountInSectionTypeByGameId(
+            @Param("gameId") Long gameId
+    );
+
+    @Query("""
+    SELECT new com.example.ticketable.domain.stadium.dto.response.SectionSeatCountResponse(
+        s.code , COUNT(st.id))
+    FROM Seat seat
+    JOIN seat.section s
+    JOIN s.stadium st
+    JOIN Game g ON g.stadium.id = st.id
+    WHERE g.id = :gameId
+      AND s.type = :type
+      AND seat.id NOT IN (
+        SELECT ts.seat.id
+        FROM TicketSeat ts
+        JOIN ts.ticket t
+        WHERE t.game.id = :gameId
+          AND t.deletedAt IS NULL
+      )
+    GROUP BY s.code
+    """)
+    List<SectionSeatCountResponse> findSectionSeatCountsBySectionId(
+            @Param("gameId") Long gameId,
+            @Param("type") String type
+    );
+
+    @Query("""
+    SELECT new com.example.ticketable.domain.stadium.dto.response.SeatGetResponse(
+        s.id, s.position, s.isBlind,
+        CASE 
+            WHEN EXISTS (
+                SELECT 1 
+                FROM TicketSeat ts 
+                JOIN ts.ticket t 
+                WHERE ts.seat = s 
+                AND t.game.id = :gameId 
+                AND t.deletedAt IS NULL
+            ) 
+            THEN true 
+            ELSE false 
+        END
+    )
+    FROM Seat s
+    WHERE s.section.id = :sectionId
+    """)
+    List<SeatGetResponse> findSeatsWithBookingStatusBySectionIdAndGameId(
+            @Param("sectionId") Long sectionId,
+            @Param("gameId") Long gameId
+    );
 }

--- a/src/main/java/com/example/ticketable/domain/game/repository/GameRepository.java
+++ b/src/main/java/com/example/ticketable/domain/game/repository/GameRepository.java
@@ -4,6 +4,14 @@ package com.example.ticketable.domain.game.repository;
 import com.example.ticketable.domain.game.entity.Game;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 public interface GameRepository extends JpaRepository<Game, Long> {
 
+    List<Game> findByHomeAndStartTimeBetween(String team, LocalDateTime startOfDay, LocalDateTime endOfDay);
+
+    List<Game> findByHome(String home);
+
+    List<Game> findByStartTimeBetween(LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/com/example/ticketable/domain/game/service/GameService.java
+++ b/src/main/java/com/example/ticketable/domain/game/service/GameService.java
@@ -9,6 +9,10 @@ import com.example.ticketable.domain.game.dto.response.GameGetResponse;
 import com.example.ticketable.domain.game.dto.response.GameUpdateResponse;
 import com.example.ticketable.domain.game.entity.Game;
 import com.example.ticketable.domain.game.repository.GameRepository;
+import com.example.ticketable.domain.stadium.dto.response.SeatGetResponse;
+import com.example.ticketable.domain.stadium.dto.response.SectionSeatCountResponse;
+import com.example.ticketable.domain.stadium.dto.response.SectionTypeSeatCountResponse;
+import com.example.ticketable.domain.stadium.dto.response.StadiumGetResponse;
 import com.example.ticketable.domain.stadium.entity.Stadium;
 import com.example.ticketable.domain.stadium.service.StadiumService;
 import lombok.RequiredArgsConstructor;
@@ -57,10 +61,24 @@ public class GameService {
             games = gameRepository.findAll();
         }
 
-
         return games.stream()
                 .map(GameGetResponse::of)
                 .collect(Collectors.toList());
+    }
+
+    public StadiumGetResponse getStadiumAndSectionSeatCounts(Long gameId) {
+        Stadium stadium = gameRepository.getStadiumByGameId(gameId);
+        List<SectionTypeSeatCountResponse> sectionBookedSeatCounts = gameRepository.findUnBookedSeatsCountInSectionTypeByGameId(gameId);
+
+        return StadiumGetResponse.of(stadium, sectionBookedSeatCounts);
+    }
+
+    public List<SectionSeatCountResponse> getAvailableSeatsBySectionType(Long gameId, String type) {
+        return gameRepository.findSectionSeatCountsBySectionId(gameId, type);
+    }
+
+    public List<SeatGetResponse> getSeatInfoBySection(Long sectionId, Long gameId) {
+        return gameRepository.findSeatsWithBookingStatusBySectionIdAndGameId(sectionId ,gameId);
     }
 
     @Transactional

--- a/src/main/java/com/example/ticketable/domain/game/service/GameService.java
+++ b/src/main/java/com/example/ticketable/domain/game/service/GameService.java
@@ -1,7 +1,85 @@
 package com.example.ticketable.domain.game.service;
 
+import com.example.ticketable.common.exception.ErrorCode;
+import com.example.ticketable.common.exception.ServerException;
+import com.example.ticketable.domain.game.dto.request.GameCreateRequest;
+import com.example.ticketable.domain.game.dto.request.GameUpdateRequest;
+import com.example.ticketable.domain.game.dto.response.GameCreateResponse;
+import com.example.ticketable.domain.game.dto.response.GameGetResponse;
+import com.example.ticketable.domain.game.dto.response.GameUpdateResponse;
+import com.example.ticketable.domain.game.entity.Game;
+import com.example.ticketable.domain.game.repository.GameRepository;
+import com.example.ticketable.domain.stadium.entity.Stadium;
+import com.example.ticketable.domain.stadium.service.StadiumService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
+@RequiredArgsConstructor
 public class GameService {
+    private final GameRepository gameRepository;
+
+    private final StadiumService stadiumService;
+
+    @Transactional
+    public GameCreateResponse createGame(GameCreateRequest request) {
+        Stadium stadium = stadiumService.getStadium(request.getStadiumId());
+        Game game = gameRepository.save(Game.builder()
+                .stadium(stadium)
+                .away(request.getAway())
+                .home(request.getHome())
+                .type(request.getType())
+                .point(request.getPoint())
+                .imagePath(request.getImagePath())
+                .startTime(request.getStartTime())
+                .build()
+        );
+        return GameCreateResponse.of(game);
+    }
+
+    public List<GameGetResponse> getGames(String team, LocalDateTime date) {
+        List<Game> games;
+
+        if (team != null && date != null) {
+            LocalDateTime[] range = getDayRange(date);
+            games = gameRepository.findByHomeAndStartTimeBetween(team, range[0], range[1]);
+        } else if (team != null) {
+            games = gameRepository.findByHome(team);
+        } else if (date != null) {
+            LocalDateTime[] range = getDayRange(date);
+            games = gameRepository.findByStartTimeBetween(range[0], range[1]);
+        } else {
+            games = gameRepository.findAll();
+        }
+
+
+        return games.stream()
+                .map(GameGetResponse::of)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public GameUpdateResponse updateGame(Long gameId, GameUpdateRequest request) {
+        Game game = gameRepository.findById(gameId).orElseThrow(() -> new ServerException(ErrorCode.GAME_NOT_FOUND));
+        game.updateStartTime(request.getStartTime());
+        return GameUpdateResponse.of(game);
+    }
+
+    @Transactional
+    public void deleteGames(Long gameId) {
+           Game game = gameRepository.findById(gameId).orElseThrow(() -> new ServerException(ErrorCode.GAME_NOT_FOUND));
+           game.cancel();
+    }
+
+    // 날짜 계산 메서드
+    private LocalDateTime[] getDayRange(LocalDateTime dateTime) {
+        LocalDateTime startOfDay = dateTime.toLocalDate().atStartOfDay();
+        LocalDateTime endOfDay = startOfDay.plusDays(1);
+        return new LocalDateTime[] { startOfDay, endOfDay };
+    }
 }

--- a/src/main/java/com/example/ticketable/domain/stadium/controller/SeatController.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/controller/SeatController.java
@@ -28,14 +28,7 @@ public class SeatController {
         return ResponseEntity.ok(seatService.createSeats(stadiumId, sectionId, request));
     }
 
-    @GetMapping("/v1/stadiums/{stadiumId}/sections/{sectionId}/seats")
-    public ResponseEntity<List<SeatGetResponse>> getSeats(
-            @PathVariable Long sectionId
-    ) {
-        return ResponseEntity.ok(seatService.getSeats(sectionId));
-    }
-
-    @PutMapping("/v1/stadiums/{stadiumId}/sections/{sectionId}/seats/{seatId}")
+    @PutMapping("/v1/seats/{seatId}")
     public ResponseEntity<SeatUpdateResponse> updateSeat(
             @PathVariable Long seatId,
             @RequestBody SeatUpdateRequest request
@@ -43,7 +36,7 @@ public class SeatController {
         return ResponseEntity.ok(seatService.updateSeat(seatId, request));
     }
 
-    @DeleteMapping("/v1/stadiums/{stadiumId}/sections/{sectionId}/seats/{seatId}")
+    @DeleteMapping("/v1/seats/{seatId}")
     public ResponseEntity<Void> deleteSeat(
             @PathVariable Long seatId
     ) {

--- a/src/main/java/com/example/ticketable/domain/stadium/controller/SectionController.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/controller/SectionController.java
@@ -26,15 +26,7 @@ public class SectionController {
         return ResponseEntity.ok(sectionService.createSection(stadiumId, request));
     }
 
-    @GetMapping("/v1/stadiums/{stadiumId}/sections")
-    public ResponseEntity<List<SectionSeatCountResponse>> getAvailableSeatsBySectionCode(
-            @PathVariable Long stadiumId,
-            @RequestParam String type
-    ) {
-        return ResponseEntity.ok(sectionService.getAvailableSeatsBySectionCode(stadiumId, type));
-    }
-
-    @PutMapping("/v1/stadiums/{stadiumId}/sections/{sectionId}")
+    @PutMapping("/v1/sections/{sectionId}")
     public ResponseEntity<SectionUpdateResponse> updateSection(
             @PathVariable Long sectionId,
             @RequestBody SectionUpdateRequest request
@@ -43,7 +35,7 @@ public class SectionController {
     }
 
 
-    @DeleteMapping("/v1/stadiums/{stadiumId}/sections/{sectionId}")
+    @DeleteMapping("/v1/sections/{sectionId}")
     public ResponseEntity<Void> deleteSection(
             @PathVariable Long sectionId
     ) {

--- a/src/main/java/com/example/ticketable/domain/stadium/controller/StadiumController.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/controller/StadiumController.java
@@ -21,11 +21,6 @@ public class StadiumController {
         return ResponseEntity.ok(stadiumService.createStadium(request));
     }
 
-    @GetMapping("/v1/stadiums/{stadiumId}")
-    public ResponseEntity<StadiumGetResponse> getStadium(@PathVariable Long stadiumId) {
-        return ResponseEntity.ok(stadiumService.getStadiumDto(stadiumId));
-    }
-
     @PutMapping("/v1/stadiums/{stadiumId}")
     public ResponseEntity<StadiumUpdateResponse> updateStadium(
             @PathVariable Long stadiumId,

--- a/src/main/java/com/example/ticketable/domain/stadium/repository/SeatRepository.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/repository/SeatRepository.java
@@ -3,21 +3,10 @@ package com.example.ticketable.domain.stadium.repository;
 
 import com.example.ticketable.domain.stadium.entity.Seat;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
-import java.util.List;
 
 public interface SeatRepository extends JpaRepository<Seat, Long> {
 
-    @Query("SELECT s FROM Seat s " +
-            "LEFT JOIN TicketSeat  ts ON s.id = ts.seat.id " +
-            "LEFT JOIN Ticket t ON ts.ticket.id = t.id AND t.deletedAt IS NOT NULL " +
-            "WHERE s.section.id = :sectionId " +
-            "AND ts IS NULL"
-            )
-    List<Seat> findUnbookSeatsBySectionId(Long sectionId);
-
-    List<Seat> findBySectionId(Long sectionId);
-
     boolean existsBySectionId(Long sectionId);
+
 }

--- a/src/main/java/com/example/ticketable/domain/stadium/repository/SectionRepository.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/repository/SectionRepository.java
@@ -4,6 +4,7 @@ package com.example.ticketable.domain.stadium.repository;
 import com.example.ticketable.domain.stadium.dto.response.SectionSeatCountResponse;
 import com.example.ticketable.domain.stadium.dto.response.SectionTypeSeatCountResponse;
 import com.example.ticketable.domain.stadium.entity.Section;
+import com.example.ticketable.domain.stadium.entity.Stadium;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -23,5 +24,7 @@ public interface SectionRepository extends JpaRepository<Section, Long> {
             "HAVING sn.type = :type"
         )
         List<SectionSeatCountResponse> findSectionSeatCountsBySectionId(@Param("stadiumId") Long stadiumId, @Param("type") String type);
+
+    boolean existsByCodeAndStadium(String code, Stadium stadium);
 }
 

--- a/src/main/java/com/example/ticketable/domain/stadium/repository/SectionRepository.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/repository/SectionRepository.java
@@ -1,29 +1,13 @@
 package com.example.ticketable.domain.stadium.repository;
 
 
-import com.example.ticketable.domain.stadium.dto.response.SectionSeatCountResponse;
-import com.example.ticketable.domain.stadium.dto.response.SectionTypeSeatCountResponse;
 import com.example.ticketable.domain.stadium.entity.Section;
 import com.example.ticketable.domain.stadium.entity.Stadium;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-import java.util.List;
 
 public interface SectionRepository extends JpaRepository<Section, Long> {
 
-        @Query("SELECT new com.example.ticketable.domain.stadium.dto.response.SectionSeatCountResponse( " +
-            "sn.code, COUNT(st.id)) " +
-            "FROM Section sn " +
-            "JOIN Seat st ON sn.id = st.section.id " +
-            "LEFT JOIN TicketSeat ts ON st.id = ts.seat.id " +
-            "WHERE sn.stadium.id = :stadiumId " +
-            "AND ts.id IS NULL " +
-            "GROUP BY sn.code, sn.type " +
-            "HAVING sn.type = :type"
-        )
-        List<SectionSeatCountResponse> findSectionSeatCountsBySectionId(@Param("stadiumId") Long stadiumId, @Param("type") String type);
 
     boolean existsByCodeAndStadium(String code, Stadium stadium);
 }

--- a/src/main/java/com/example/ticketable/domain/stadium/repository/StadiumRepository.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/repository/StadiumRepository.java
@@ -1,25 +1,12 @@
 package com.example.ticketable.domain.stadium.repository;
 
-
-import com.example.ticketable.domain.stadium.dto.response.SectionTypeSeatCountResponse;
 import com.example.ticketable.domain.stadium.entity.Stadium;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-import java.util.List;
 
 public interface StadiumRepository extends JpaRepository<Stadium, Long> {
 
-    @Query("SELECT new com.example.ticketable.domain.stadium.dto.response.SectionTypeSeatCountResponse( " +
-            "sn.type, COUNT(st.id)) " +
-            "FROM Section sn " +
-            "JOIN Seat st ON sn.id = st.section.id " +
-            "LEFT JOIN TicketSeat ts ON st.id = ts.seat.id " +
-            "WHERE sn.stadium.id = :stadiumId " +
-            "AND ts.id IS NULL " +
-            "GROUP BY sn.type")
-    List<SectionTypeSeatCountResponse> findSectionTypeAndSeatCountsByStadiumId(@Param("stadiumId") Long stadiumId);
 
     boolean existsByName(String name);
+
 }

--- a/src/main/java/com/example/ticketable/domain/stadium/repository/StadiumRepository.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/repository/StadiumRepository.java
@@ -21,4 +21,5 @@ public interface StadiumRepository extends JpaRepository<Stadium, Long> {
             "GROUP BY sn.type")
     List<SectionTypeSeatCountResponse> findSectionTypeAndSeatCountsByStadiumId(@Param("stadiumId") Long stadiumId);
 
+    boolean existsByName(String name);
 }

--- a/src/main/java/com/example/ticketable/domain/stadium/service/SeatService.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/service/SeatService.java
@@ -72,24 +72,6 @@ public class SeatService {
         return seatList;
     }
 
-    public List<SeatGetResponse> getSeats(Long sectionId) {
-        List<Seat> seatList = seatRepository.findBySectionId(sectionId);
-        List<Seat> unbookSeatList = seatRepository.findUnbookSeatsBySectionId(sectionId);
-
-        Set<Long> unbookedSeatIds = new HashSet<>();
-        for (Seat seat : unbookSeatList) {
-                unbookedSeatIds.add(seat.getId());
-        }
-
-        List<SeatGetResponse> responseList = new ArrayList<>();
-        for (Seat seat : seatList) {
-            boolean isBooked = !unbookedSeatIds.contains(seat.getId());
-            SeatGetResponse response = SeatGetResponse.of(seat, isBooked);
-            responseList.add(response);
-        }
-        return responseList;
-    }
-
     @Transactional
     public SeatUpdateResponse updateSeat(Long seatId, SeatUpdateRequest request) {
         Seat seat = seatRepository.findById(seatId).orElseThrow(() -> new ServerException(ErrorCode.SEAT_NOT_FOUND));

--- a/src/main/java/com/example/ticketable/domain/stadium/service/SectionService.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/service/SectionService.java
@@ -28,6 +28,10 @@ public class SectionService {
     public SectionCreateResponse createSection(Long stadiumId, SectionCreateRequest request) {
         Stadium stadium = stadiumService.getStadium(stadiumId);
 
+        if(sectionRepository.existsByCodeAndStadium(request.getCode(), stadium)){
+            throw new ServerException(ErrorCode.SECTION_CODE_DUPLICATION);
+        }
+
         Section section = sectionRepository.save(
                 Section.builder()
                         .type(request.getType())
@@ -42,6 +46,10 @@ public class SectionService {
     @Transactional
     public SectionUpdateResponse updateSection(Long sectionId, SectionUpdateRequest request) {
         Section section = getById(sectionId);
+
+        if(sectionRepository.existsByCodeAndStadium(request.getCode(), section.getStadium())) {
+            throw new ServerException(ErrorCode.SECTION_CODE_DUPLICATION);
+        }
 
         section.updateType(request.getType());
         section.updateCode(request.getCode());

--- a/src/main/java/com/example/ticketable/domain/stadium/service/SectionService.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/service/SectionService.java
@@ -11,7 +11,6 @@ import com.example.ticketable.domain.stadium.entity.Section;
 import com.example.ticketable.domain.stadium.entity.Stadium;
 import com.example.ticketable.domain.stadium.repository.SectionRepository;
 import lombok.RequiredArgsConstructor;
-import org.apache.catalina.Server;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -66,9 +65,5 @@ public class SectionService {
 
     public Section getById(Long sectionId) {
         return sectionRepository.findById(sectionId).orElseThrow(() -> new ServerException(ErrorCode.SECTION_NOT_FOUND));
-    }
-
-    public List<SectionSeatCountResponse> getAvailableSeatsBySectionCode(Long stadiumId, String type) {
-        return sectionRepository.findSectionSeatCountsBySectionId(stadiumId, type);
     }
 }

--- a/src/main/java/com/example/ticketable/domain/stadium/service/StadiumService.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/service/StadiumService.java
@@ -38,13 +38,6 @@ public class StadiumService {
     }
 
 
-    public StadiumGetResponse getStadiumDto(Long stadiumId) {
-        Stadium stadium = getStadium(stadiumId);
-        List<SectionTypeSeatCountResponse> sectionSeatCounts = stadiumRepository.findSectionTypeAndSeatCountsByStadiumId(stadiumId);
-
-        return StadiumGetResponse.of(stadium, sectionSeatCounts);
-    }
-
     @Transactional
     public StadiumUpdateResponse updateStadium(Long stadiumId, StadiumUpdateRequest request) {
         Stadium stadium = getStadium(stadiumId);
@@ -68,4 +61,5 @@ public class StadiumService {
     public Stadium getStadium(Long stadiumId) {
          return stadiumRepository.findById(stadiumId).orElseThrow(()-> new ServerException(ErrorCode.STADIUM_NOT_FOUND));
     }
+
 }

--- a/src/main/java/com/example/ticketable/domain/stadium/service/StadiumService.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/service/StadiumService.java
@@ -23,6 +23,9 @@ public class StadiumService {
 
     @Transactional
     public StadiumCreateResponse createStadium(StadiumCreateRequest request) {
+        if(stadiumRepository.existsByName(request.getName())){
+            throw new ServerException(ErrorCode.STADIUM_NAME_DUPLICATION);
+        }
         Stadium stadium = stadiumRepository.save(
                 Stadium.builder()
                         .name(request.getName())
@@ -45,6 +48,10 @@ public class StadiumService {
     @Transactional
     public StadiumUpdateResponse updateStadium(Long stadiumId, StadiumUpdateRequest request) {
         Stadium stadium = getStadium(stadiumId);
+
+        if(stadiumRepository.existsByName(request.getName())){
+            throw new ServerException(ErrorCode.STADIUM_NAME_DUPLICATION);
+        }
 
         stadium.updateName(request.getName());
         stadium.updateImagePath("새로운 이미지 경로");


### PR DESCRIPTION
## 📌 PR 요약
- 경기 CRUD 구현
- 경기장과 구역, 좌석 관련된 정보를 조회할 때 남은 좌석 정보를 가져올때 해당 경기에 대해서만 가져오도록 수정
- API URL 수정

## 🔗 관련 이슈
- 관련된 이슈 번호를 연결해주세요.
    - closed #3 #15

## 🛠️ 변경 사항
- 주요 변경 사항을 bullet으로 작성해주세요.
    - 경기 관련 API 추가
    - 조회 쿼리 로직 수정 및 서브 쿼리를 이용해서 DB와의 연결을 한번에 하도록 수정 
    - 조회할 때 모두 경기 관련하여 해당 경기에 대한 정보를 가져와야 되기 때문에 game 쪽 서비스에서 조회를 모두 진행하도록 변경 

## 📸 스크린샷 (선택)

| 기능 | 스크린샷 |
| --- | --- |
| 경기 저장 | ![image](https://github.com/user-attachments/assets/ed57fe25-6b2a-44ed-a264-9706d7d58934) |
| 경기 조회 | ![image](https://github.com/user-attachments/assets/484d26ef-e8b6-48c3-8b64-8216d1908ff9) |
| 경기장 정보 및 해당 경기의 구역별 남은 좌석 조회 | ![image](https://github.com/user-attachments/assets/bb01ba27-0d6a-494a-a670-7d5a141ac28b) |
| 구역 타입별 남은 좌석 조회 | ![image](https://github.com/user-attachments/assets/5dccfbe0-c879-4a8c-862b-5ee4aa5bb9de) |
| 한 구역의 남은 좌석 조회 |![image](https://github.com/user-attachments/assets/be7f949b-ab85-4d8a-9fc6-b2908f2413bb) |

## ⚠️ 주의 사항 (선택)
URL이 전체적으로 수정되었습니다! 이전 URL을 돌리실 경우 안돌아갈 수 있습니다!

## ✅ 체크리스트
PR 작성자가 확인해야 할 항목입니다:
- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] 코드 리뷰어를 등록했습니다.
- [x] Labels를 등록했습니다.