### PR TITLE
✨ Feat: 예매로직 트랜잭션 분리 버전 추가, 좌석선점 버전 추가

### DIFF
--- a/src/main/java/com/example/ticketable/common/exception/ServerException.java
+++ b/src/main/java/com/example/ticketable/common/exception/ServerException.java
@@ -1,10 +1,13 @@
 package com.example.ticketable.common.exception;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class ServerException extends RuntimeException {
 	private final ErrorCode errorCode;
+
+	public ServerException(ErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
+	}
 }

--- a/src/main/java/com/example/ticketable/common/util/SeatHoldRedisUtil.java
+++ b/src/main/java/com/example/ticketable/common/util/SeatHoldRedisUtil.java
@@ -1,0 +1,90 @@
+package com.example.ticketable.common.util;
+
+import static com.example.ticketable.common.exception.ErrorCode.TICKET_ALREADY_RESERVED;
+
+import com.example.ticketable.common.exception.ServerException;
+import java.time.Duration;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SeatHoldRedisUtil {
+	private final RedisTemplate<String, String> redisTemplate;
+	private static final Duration SEAT_HOLD_TTL = Duration.ofMinutes(15);
+	private static final String SEAT_HOLD_TTL_STRING = String.valueOf(SEAT_HOLD_TTL.getSeconds());
+	private static final DefaultRedisScript<Long> defaultRedisScript;
+
+	static {
+		defaultRedisScript = new DefaultRedisScript<>();
+		defaultRedisScript.setResultType(Long.class);
+	}
+
+	public void holdSeat(List<Long> seatIds, Long gameId, String value) {
+		for (Long seatId : seatIds) {
+			String key = createKey(seatId, gameId);
+			Boolean isNew = redisTemplate.opsForValue().setIfAbsent(key, value, SEAT_HOLD_TTL);
+			if (Boolean.FALSE.equals(isNew)) {
+				throw new ServerException(TICKET_ALREADY_RESERVED);
+			}
+		}
+	}
+
+	public void holdSeatAtomic(List<Long> seatIds, Long gameId, String value) {
+		defaultRedisScript.setLocation(new ClassPathResource("lua/holdSeat.lua"));
+
+		List<String> keys = seatIds.stream().map(id -> createKey(id, gameId)).toList();
+		Long execute = redisTemplate.execute(defaultRedisScript, keys, value, SEAT_HOLD_TTL_STRING);
+
+		if(execute == null || execute.equals(0L)) {
+			throw new ServerException(TICKET_ALREADY_RESERVED);
+		}
+	}
+
+	public void releaseSeat(List<Long> seatIds, Long gameId) {
+		for (Long seatId : seatIds) {
+			String key = createKey(seatId, gameId);
+			redisTemplate.delete(key);
+		}
+	}
+
+	public void releaseSeatAtomic(List<Long> seatIds, Long gameId) {
+		defaultRedisScript.setLocation(new ClassPathResource("lua/releaseSeat.lua"));
+
+		List<String> keys = seatIds.stream().map(id -> createKey(id, gameId)).toList();
+		redisTemplate.execute(defaultRedisScript, keys);
+	}
+
+	public void checkHeldSeat(List<Long> seatIds, Long gameId, String value) {
+		for (Long seatId : seatIds) {
+			String key = createKey(seatId, gameId);
+			String v = redisTemplate.opsForValue().get(key);
+
+			if (v == null || !v.equals(value)) {
+				throw new ServerException(TICKET_ALREADY_RESERVED);
+			}
+		}
+	}
+
+	public void checkHeldSeatAtomic(List<Long> seatIds, Long gameId, String value) {
+		defaultRedisScript.setLocation(new ClassPathResource("lua/checkHeldSeat.lua"));
+
+		List<String> keys = seatIds.stream().map(id -> createKey(id, gameId)).toList();
+		Long isHeld = redisTemplate.execute(defaultRedisScript, keys, value);
+
+		if (isHeld == null || isHeld.equals(0L)) {
+			throw new ServerException(TICKET_ALREADY_RESERVED);
+		}
+
+	}
+
+	public String createKey(Long seatId, Long gameId){
+		return String.format("game:%d:seat:%d", gameId, seatId);
+	}
+}

--- a/src/main/java/com/example/ticketable/domain/game/entity/Game.java
+++ b/src/main/java/com/example/ticketable/domain/game/entity/Game.java
@@ -31,10 +31,6 @@ public class Game {
 	@Column(length = 20)
 	@Enumerated(EnumType.STRING)
 	private GameType type;
-
-	@ManyToOne
-	@JoinColumn(name = "stadium_id")
-	private Stadium stadium;
 	
 	private Integer point;
 

--- a/src/main/java/com/example/ticketable/domain/stadium/controller/SeatController.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/controller/SeatController.java
@@ -1,16 +1,23 @@
 package com.example.ticketable.domain.stadium.controller;
 
+import com.example.ticketable.common.entity.Auth;
 import com.example.ticketable.domain.stadium.dto.request.SeatCreateRequest;
+import com.example.ticketable.domain.stadium.dto.request.SeatHoldRequest;
 import com.example.ticketable.domain.stadium.dto.request.SeatUpdateRequest;
 import com.example.ticketable.domain.stadium.dto.response.SeatCreateResponse;
-import com.example.ticketable.domain.stadium.dto.response.SeatGetResponse;
 import com.example.ticketable.domain.stadium.dto.response.SeatUpdateResponse;
 import com.example.ticketable.domain.stadium.service.SeatService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 
 @RestController
@@ -42,5 +49,16 @@ public class SeatController {
     ) {
         seatService.delete(seatId);
         return ResponseEntity.ok().build();
+    }
+
+    // 좌석 선점
+    @PostMapping("/v1/seats/hold")
+    public ResponseEntity<String> holdSeat(
+        @AuthenticationPrincipal Auth auth,
+        @RequestBody SeatHoldRequest seatHoldRequest
+    ) {
+        seatService.holdSeat(auth, seatHoldRequest);
+
+        return ResponseEntity.ok("모든 좌석 선점 성공, 15분안에 결제를 완료해주세요");
     }
 }

--- a/src/main/java/com/example/ticketable/domain/stadium/dto/request/SeatHoldRequest.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/dto/request/SeatHoldRequest.java
@@ -1,0 +1,13 @@
+package com.example.ticketable.domain.stadium.dto.request;
+
+import jakarta.validation.GroupSequence;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SeatHoldRequest {
+	private List<Long> seatIds;
+	private Long gameId;
+}

--- a/src/main/java/com/example/ticketable/domain/ticket/controller/TicketController.java
+++ b/src/main/java/com/example/ticketable/domain/ticket/controller/TicketController.java
@@ -38,14 +38,14 @@ public class TicketController {
 	@PostMapping("/v1/tickets")
 	public ResponseEntity<TicketResponse> createTicket(@AuthenticationPrincipal Auth auth,
 		@RequestBody TicketCreateRequest ticketCreateRequest) {
-		TicketResponse ticketResponse = ticketService.createTicket(auth, ticketCreateRequest);
+		TicketResponse ticketResponse = ticketService.reservationTicketV2(auth, ticketCreateRequest);
 		return ResponseEntity.ok().body(ticketResponse);
 	}
 
 	@DeleteMapping("/v1/tickets/{ticketId}")
 	public ResponseEntity<Void> deleteTicket(@AuthenticationPrincipal Auth auth,
 		@PathVariable Long ticketId) {
-		ticketService.deleteTicket(auth, ticketId);
+		ticketService.cancelTicket(auth, ticketId);
 
 		return ResponseEntity.noContent().build();
 	}

--- a/src/main/java/com/example/ticketable/domain/ticket/controller/TicketController.java
+++ b/src/main/java/com/example/ticketable/domain/ticket/controller/TicketController.java
@@ -38,7 +38,21 @@ public class TicketController {
 	@PostMapping("/v1/tickets")
 	public ResponseEntity<TicketResponse> createTicket(@AuthenticationPrincipal Auth auth,
 		@RequestBody TicketCreateRequest ticketCreateRequest) {
+		TicketResponse ticketResponse = ticketService.reservationTicket(auth, ticketCreateRequest);
+		return ResponseEntity.ok().body(ticketResponse);
+	}
+
+	@PostMapping("/v2/tickets")
+	public ResponseEntity<TicketResponse> createTicketV2(@AuthenticationPrincipal Auth auth,
+		@RequestBody TicketCreateRequest ticketCreateRequest) {
 		TicketResponse ticketResponse = ticketService.reservationTicketV2(auth, ticketCreateRequest);
+		return ResponseEntity.ok().body(ticketResponse);
+	}
+
+	@PostMapping("/v3/tickets")
+	public ResponseEntity<TicketResponse> createTicketV3(@AuthenticationPrincipal Auth auth,
+		@RequestBody TicketCreateRequest ticketCreateRequest) {
+		TicketResponse ticketResponse = ticketService.reservationTicketV3(auth, ticketCreateRequest);
 		return ResponseEntity.ok().body(ticketResponse);
 	}
 

--- a/src/main/java/com/example/ticketable/domain/ticket/dto/TicketContext.java
+++ b/src/main/java/com/example/ticketable/domain/ticket/dto/TicketContext.java
@@ -1,0 +1,30 @@
+package com.example.ticketable.domain.ticket.dto;
+
+import com.example.ticketable.domain.game.entity.Game;
+import com.example.ticketable.domain.member.entity.Member;
+import com.example.ticketable.domain.stadium.entity.Seat;
+import com.example.ticketable.domain.ticket.dto.response.TicketResponse;
+import com.example.ticketable.domain.ticket.entity.Ticket;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TicketContext {
+	private final Ticket ticket;
+	private final Member member;
+	private final Game game;
+	private final List<Seat> seats;
+	private final int totalPoint;
+
+	public TicketResponse toResponse() {
+		return new TicketResponse(
+			ticket.getId(),
+			game.getHome() + " vs " + game.getAway(),
+			seats.stream().map(Seat::getPosition).toList(),
+			game.getStartTime(),
+			totalPoint
+		);
+	}
+}

--- a/src/main/java/com/example/ticketable/domain/ticket/entity/Ticket.java
+++ b/src/main/java/com/example/ticketable/domain/ticket/entity/Ticket.java
@@ -15,8 +15,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
@@ -42,7 +40,7 @@ public class Ticket {
 		this.game = game;
 	}
 
-	public void delete() {
+	public void cancel() {
 		deletedAt = LocalDateTime.now();
 	}
 }

--- a/src/main/java/com/example/ticketable/domain/ticket/repository/TicketSeatRepository.java
+++ b/src/main/java/com/example/ticketable/domain/ticket/repository/TicketSeatRepository.java
@@ -1,8 +1,10 @@
 package com.example.ticketable.domain.ticket.repository;
 
 import com.example.ticketable.domain.ticket.entity.TicketSeat;
+import jakarta.persistence.LockModeType;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 
 public interface TicketSeatRepository extends JpaRepository<TicketSeat, Long> {
@@ -13,6 +15,8 @@ public interface TicketSeatRepository extends JpaRepository<TicketSeat, Long> {
 		+ "    and ts.ticket.deletedAt is null ")
 	List<TicketSeat> findByTicketIdWithSeat(Long ticketId);
 
-	//@Lock(value = LockModeType.PESSIMISTIC_WRITE)
-	boolean existsByGameIdAndSeatIdInAndTicketDeletedAtIsNull(Long gameId, List<Long> seatIds);
+	//@Lock(LockModeType.PESSIMISTIC_WRITE)
+	List<TicketSeat> findAllByGameIdAndSeatIdInAndTicketDeletedAtIsNull(Long gameId, List<Long> seatIds);
+
+	void deleteAllByTicketId(Long ticketId);
 }

--- a/src/main/java/com/example/ticketable/domain/ticket/repository/TicketSeatRepository.java
+++ b/src/main/java/com/example/ticketable/domain/ticket/repository/TicketSeatRepository.java
@@ -1,10 +1,8 @@
 package com.example.ticketable.domain.ticket.repository;
 
 import com.example.ticketable.domain.ticket.entity.TicketSeat;
-import jakarta.persistence.LockModeType;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 
 public interface TicketSeatRepository extends JpaRepository<TicketSeat, Long> {
@@ -15,8 +13,8 @@ public interface TicketSeatRepository extends JpaRepository<TicketSeat, Long> {
 		+ "    and ts.ticket.deletedAt is null ")
 	List<TicketSeat> findByTicketIdWithSeat(Long ticketId);
 
-	//@Lock(LockModeType.PESSIMISTIC_WRITE)
-	List<TicketSeat> findAllByGameIdAndSeatIdInAndTicketDeletedAtIsNull(Long gameId, List<Long> seatIds);
+
+	boolean existsByGameIdAndSeatIdInAndTicketDeletedAtIsNull(Long gameId, List<Long> seatIds);
 
 	void deleteAllByTicketId(Long ticketId);
 }

--- a/src/main/java/com/example/ticketable/domain/ticket/service/TicketCreateService.java
+++ b/src/main/java/com/example/ticketable/domain/ticket/service/TicketCreateService.java
@@ -1,0 +1,53 @@
+package com.example.ticketable.domain.ticket.service;
+
+import com.example.ticketable.common.entity.Auth;
+import com.example.ticketable.domain.game.entity.Game;
+import com.example.ticketable.domain.game.service.GameService;
+import com.example.ticketable.domain.member.entity.Member;
+import com.example.ticketable.domain.stadium.entity.Seat;
+import com.example.ticketable.domain.stadium.service.SeatService;
+import com.example.ticketable.domain.ticket.dto.TicketContext;
+import com.example.ticketable.domain.ticket.dto.request.TicketCreateRequest;
+import com.example.ticketable.domain.ticket.entity.Ticket;
+import com.example.ticketable.domain.ticket.repository.TicketRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TicketCreateService {
+
+	private final TicketRepository ticketRepository;
+	private final TicketSeatService ticketSeatService;
+	private final SeatService seatService;
+	private final GameService gameService;
+	private final TicketPriceCalculator ticketPriceCalculator;
+
+	//티켓 생성
+	@Transactional
+	public TicketContext createTicket(Auth auth, TicketCreateRequest ticketCreateRequest) {
+
+		ticketSeatService.checkDuplicateSeats(ticketCreateRequest.getSeats(), ticketCreateRequest.getGameId());
+
+		List<Seat> seats = seatService.getAllSeatEntity(ticketCreateRequest.getSeats());
+		Game game = gameService.getGameEntity(ticketCreateRequest.getGameId());
+
+		Member member = Member.fromAuth(auth.getId());
+		Ticket ticket = ticketRepository.save(new Ticket(member, game));
+		ticketSeatService.createAll(seats, game, ticket);
+
+		int totalPrice = ticketPriceCalculator.calculateTicketPrice(game, seats);
+
+		return new TicketContext(ticket, member, game, seats, totalPrice);
+	}
+
+	//생성된 티켓 롤백
+	@Transactional
+	public void rollBackTicket(Ticket ticket) {
+		ticketSeatService.deleteAllTicketSeats(ticket.getId());
+		ticketRepository.delete(ticket);
+	}
+
+}

--- a/src/main/java/com/example/ticketable/domain/ticket/service/TicketCreateService.java
+++ b/src/main/java/com/example/ticketable/domain/ticket/service/TicketCreateService.java
@@ -1,6 +1,8 @@
 package com.example.ticketable.domain.ticket.service;
 
 import com.example.ticketable.common.entity.Auth;
+import com.example.ticketable.common.exception.ServerException;
+import com.example.ticketable.common.util.SeatHoldRedisUtil;
 import com.example.ticketable.domain.game.entity.Game;
 import com.example.ticketable.domain.game.service.GameService;
 import com.example.ticketable.domain.member.entity.Member;
@@ -24,12 +26,36 @@ public class TicketCreateService {
 	private final SeatService seatService;
 	private final GameService gameService;
 	private final TicketPriceCalculator ticketPriceCalculator;
+	private final SeatHoldRedisUtil seatHoldRedisUtil;
 
 	//티켓 생성
 	@Transactional
 	public TicketContext createTicket(Auth auth, TicketCreateRequest ticketCreateRequest) {
 
 		ticketSeatService.checkDuplicateSeats(ticketCreateRequest.getSeats(), ticketCreateRequest.getGameId());
+
+		List<Seat> seats = seatService.getAllSeatEntity(ticketCreateRequest.getSeats());
+		Game game = gameService.getGameEntity(ticketCreateRequest.getGameId());
+
+		Member member = Member.fromAuth(auth.getId());
+		Ticket ticket = ticketRepository.save(new Ticket(member, game));
+		ticketSeatService.createAll(seats, game, ticket);
+
+		int totalPrice = ticketPriceCalculator.calculateTicketPrice(game, seats);
+
+		return new TicketContext(ticket, member, game, seats, totalPrice);
+	}
+
+	@Transactional
+	public TicketContext createTicketV2(Auth auth, TicketCreateRequest ticketCreateRequest) {
+
+		seatHoldRedisUtil.checkHeldSeat(ticketCreateRequest.getSeats(), ticketCreateRequest.getGameId(), String.valueOf(auth.getId()));
+		try {
+			ticketSeatService.checkDuplicateSeats(ticketCreateRequest.getSeats(), ticketCreateRequest.getGameId());
+		} catch (ServerException e) {
+			seatHoldRedisUtil.releaseSeatAtomic(ticketCreateRequest.getSeats(), ticketCreateRequest.getGameId());
+			throw e;
+		}
 
 		List<Seat> seats = seatService.getAllSeatEntity(ticketCreateRequest.getSeats());
 		Game game = gameService.getGameEntity(ticketCreateRequest.getGameId());

--- a/src/main/java/com/example/ticketable/domain/ticket/service/TicketPaymentService.java
+++ b/src/main/java/com/example/ticketable/domain/ticket/service/TicketPaymentService.java
@@ -4,16 +4,29 @@ import static com.example.ticketable.common.exception.ErrorCode.TICKET_PAYMENT_N
 
 import com.example.ticketable.common.exception.ServerException;
 import com.example.ticketable.domain.member.entity.Member;
+import com.example.ticketable.domain.point.enums.PointHistoryType;
+import com.example.ticketable.domain.point.service.PointService;
+import com.example.ticketable.domain.ticket.dto.TicketContext;
 import com.example.ticketable.domain.ticket.entity.Ticket;
 import com.example.ticketable.domain.ticket.entity.TicketPayment;
 import com.example.ticketable.domain.ticket.repository.TicketPaymentRepository;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @AllArgsConstructor
 public class TicketPaymentService {
+
 	private final TicketPaymentRepository ticketPaymentRepository;
+	private PointService pointService;
+
+	@Transactional
+	public void paymentTicket(TicketContext ticketContext) {
+		pointService.decreasePoint(ticketContext.getMember().getId(), ticketContext.getTotalPoint(),
+			PointHistoryType.RESERVATION);
+		create(ticketContext.getTicket(), ticketContext.getMember(), ticketContext.getTotalPoint());
+	}
 
 	public void create(Ticket ticket, Member member, int point) {
 		TicketPayment ticketPayment = new TicketPayment(point, ticket, member);

--- a/src/main/java/com/example/ticketable/domain/ticket/service/TicketPriceCalculator.java
+++ b/src/main/java/com/example/ticketable/domain/ticket/service/TicketPriceCalculator.java
@@ -25,7 +25,6 @@ public class TicketPriceCalculator {
 
 		}
 
-
 		return ticketPrice;
 	}
 }

--- a/src/main/java/com/example/ticketable/domain/ticket/service/TicketSeatService.java
+++ b/src/main/java/com/example/ticketable/domain/ticket/service/TicketSeatService.java
@@ -25,7 +25,7 @@ public class TicketSeatService {
 	}
 
 	public void checkDuplicateSeats(List<Long> seatIds, Long gameId) {
-		if(!ticketSeatRepository.findAllByGameIdAndSeatIdInAndTicketDeletedAtIsNull(gameId, seatIds).isEmpty()) {
+		if(ticketSeatRepository.existsByGameIdAndSeatIdInAndTicketDeletedAtIsNull(gameId, seatIds)) {
 			log.debug("이미 예매된 좌석입니다.");
 			throw new ServerException(TICKET_ALREADY_RESERVED);
 		}

--- a/src/main/java/com/example/ticketable/domain/ticket/service/TicketSeatService.java
+++ b/src/main/java/com/example/ticketable/domain/ticket/service/TicketSeatService.java
@@ -24,12 +24,11 @@ public class TicketSeatService {
 		ticketSeatRepository.saveAll(ticketSeats);
 	}
 
-	public boolean checkDuplicateSeats(List<Long> seatIds, Long gameId) {
-		if(ticketSeatRepository.existsByGameIdAndSeatIdInAndTicketDeletedAtIsNull(gameId, seatIds)) {
+	public void checkDuplicateSeats(List<Long> seatIds, Long gameId) {
+		if(!ticketSeatRepository.findAllByGameIdAndSeatIdInAndTicketDeletedAtIsNull(gameId, seatIds).isEmpty()) {
 			log.debug("이미 예매된 좌석입니다.");
 			throw new ServerException(TICKET_ALREADY_RESERVED);
 		}
-		return true;
 	}
 
 	public List<String> getTicketSeatsToString(Long ticketId) {
@@ -37,5 +36,9 @@ public class TicketSeatService {
 			.stream()
 			.map(ticketSeat -> ticketSeat.getSeat().getPosition())
 			.toList();
+	}
+
+	public void deleteAllTicketSeats(Long ticketId) {
+		ticketSeatRepository.deleteAllByTicketId(ticketId);
 	}
 }

--- a/src/main/resources/lua/checkHeldSeat.lua
+++ b/src/main/resources/lua/checkHeldSeat.lua
@@ -1,0 +1,9 @@
+local keys = KEYS
+local value = ARGV[1]
+
+for i=1, #keys do
+	if redis.call('get', keys[i])!= value
+		return 0;
+end
+
+return 1;

--- a/src/main/resources/lua/holdSeat.lua
+++ b/src/main/resources/lua/holdSeat.lua
@@ -1,0 +1,18 @@
+local keys = KEYS
+local value = ARGV[1]
+local ttl = tonumber(ARGV[2])
+
+-- 1. 중복 체크
+for i = 1, #keys do
+  if redis.call('exists', keys[i]) == 1 then
+    return 0
+  end
+end
+
+-- 2. 모두 설정
+for i = 1, #keys do
+  redis.call('set', keys[i], value)
+  redis.call('expire', keys[i], ttl)
+end
+
+return 1

--- a/src/main/resources/lua/releaseSeat.lua
+++ b/src/main/resources/lua/releaseSeat.lua
@@ -1,0 +1,7 @@
+local keys = KEYS
+
+for i=1, #keys do
+	redis.call('del', keys[i])
+end
+
+return 1;

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,21 @@
+spring.application.name=ticketable
+
+
+spring.datasource.url=jdbc:mysql://localhost:3307/sparta
+spring.datasource.username=root
+spring.datasource.password=1234
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+spring.jpa.hibernate.ddl-auto=create
+spring.jpa.properties.hibernate.show_sql=true
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.use_sql_comments=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
+spring.jpa.defer-datasource-initialization= true
+
+jwt.secret.key=7Iqk7YyM66W07YOA7L2U65Sp7YG065+9U3ByaW5n6rCV7J2Y7Yqc7YSw7LWc7JuQ67mI7J6F64uI64ukLg
+
+logging.level.com.example.ticketable = debug
+jwt.access.token=3600000
+
+spring.sql.init.mode = always


### PR DESCRIPTION
## 📌 PR 요약
- 예매로직 트랜잭션 분리 버전 추가, 좌석선점 버전 추가

## 🔗 관련 이슈
- 관련된 이슈 번호를 연결해주세요.
    - closed #1

## 🛠️ 변경 사항
- 주요 변경 사항을 bullet으로 작성해주세요.
    -  좌석 선점 api 추가 : `/api/v1/seats/hold`
    -  예매로직 트랜잭션 분리 버전 추가
      -  reservationTicketV2
    -  좌석선점 버전 추가
      -  reservationTicketV3
    - 좌석 선점 기능은 redis사용

## 📸 스크린샷 (선택)
UI 변경 사항이 있다면 스크린샷을 첨부해주세요.

| 기능 | 스크린샷 |
| --- | --- |
| PNG | ![image](https://github.com/user-attachments/assets/f91ff995-c148-4153-b271-ba17339b93e3) |
| PNG | ![image](https://github.com/user-attachments/assets/b860eda6-31ce-4263-a168-ca544f3992f3) |

## ⚠️ 주의 사항 (선택)
리뷰어가 알아야 할 중요한 사항이나 주의할 점을 작성해주세요.

## ✅ 체크리스트
PR 작성자가 확인해야 할 항목입니다:
- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] 코드 리뷰어를 등록했습니다.
- [x] Labels를 등록했습니다.