### PR TITLE
✨ Feat: 경기, 경기장, 구역, 좌석 생성 및 수정 삭제 권한 추가

### DIFF
--- a/src/main/java/com/example/ticketable/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/ticketable/common/config/SecurityConfig.java
@@ -1,9 +1,11 @@
 package com.example.ticketable.common.config;
 
 import com.example.ticketable.common.filter.JwtAuthenticationFilter;
+import com.example.ticketable.domain.member.role.MemberRole;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -38,6 +40,11 @@ public class SecurityConfig {
 			.rememberMe(AbstractHttpConfigurer::disable)
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers("/api/v1/auth/**").permitAll()
+				.requestMatchers(HttpMethod.GET,"/api/v1/games/**").authenticated()
+				.requestMatchers("/api/v1/games/**").hasAuthority(MemberRole.Authority.ADMIN)
+				.requestMatchers("/api/v1/stadiums/**").hasAuthority(MemberRole.Authority.ADMIN)
+				.requestMatchers("/api/v1/sections/**").hasAuthority(MemberRole.Authority.ADMIN)
+				.requestMatchers("/api/v1/seats/**").hasAuthority(MemberRole.Authority.ADMIN)
 				.anyRequest().authenticated()
 			);
 		

--- a/src/main/java/com/example/ticketable/domain/game/entity/Game.java
+++ b/src/main/java/com/example/ticketable/domain/game/entity/Game.java
@@ -31,10 +31,6 @@ public class Game {
 	@Column(length = 20)
 	@Enumerated(EnumType.STRING)
 	private GameType type;
-
-	@ManyToOne
-	@JoinColumn(name = "stadium_id")
-	private Stadium stadium;
 	
 	private Integer point;
 

--- a/src/main/java/com/example/ticketable/domain/game/service/GameService.java
+++ b/src/main/java/com/example/ticketable/domain/game/service/GameService.java
@@ -15,6 +15,7 @@ import com.example.ticketable.domain.stadium.dto.response.SectionTypeSeatCountRe
 import com.example.ticketable.domain.stadium.dto.response.StadiumGetResponse;
 import com.example.ticketable.domain.stadium.entity.Stadium;
 import com.example.ticketable.domain.stadium.service.StadiumService;
+import com.example.ticketable.domain.ticket.service.TicketService;
 import lombok.RequiredArgsConstructor;
 import static com.example.ticketable.common.exception.ErrorCode.USER_ACCESS_DENIED;
 

--- a/src/main/java/com/example/ticketable/domain/stadium/dto/request/SeatUpdateRequest.java
+++ b/src/main/java/com/example/ticketable/domain/stadium/dto/request/SeatUpdateRequest.java
@@ -1,10 +1,12 @@
 package com.example.ticketable.domain.stadium.dto.request;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Getter
+@NoArgsConstructor
 public class SeatUpdateRequest {
 
     private boolean isBlind;


### PR DESCRIPTION
## 📌 PR 요약
- 경기, 경기장, 구역, 좌석 생성 및 수정 삭제 권한 추가
- 사소한 에러 해결


## 🛠️ 변경 사항
- 주요 변경 사항을 bullet으로 작성해주세요.
    - 경기, 경기장, 구역, 좌석 생성을 ADMIN 권한의 멤버로 진행해주셔야합니다!


## ⚠️ 주의 사항 (선택)
경기, 경기장, 구역, 좌석 생성을 ADMIN 권한의 멤버로 진행

## ✅ 체크리스트
PR 작성자가 확인해야 할 항목입니다:
- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] 코드 리뷰어를 등록했습니다.
- [x] Labels를 등록했습니다.