### PR TITLE
✨ Feat: 캐싱 기능 추가 및 쿼리 최적화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
-    testImplementation 'com.h2database:h2'      // 테스트 환경에서 H2 사용 runtimeOnly -> testImplementation 변경
+    runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -63,6 +63,13 @@ dependencies {
 
     // thymeleaf
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+
+    // Cache
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
+
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation("io.micrometer:micrometer-registry-prometheus")
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/ticketable/common/config/CachingConfig.java
+++ b/src/main/java/com/example/ticketable/common/config/CachingConfig.java
@@ -1,0 +1,57 @@
+package com.example.ticketable.common.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.RedisSerializer;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@EnableCaching
+@Configuration
+public class CachingConfig {
+
+    @Bean
+    public CacheManager cacheManager() {
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager("seatCountsBySectionType");
+
+        cacheManager.setCaffeine(
+                Caffeine.newBuilder()
+                        .expireAfterWrite(30, TimeUnit.MINUTES) // 30분 후 자동 삭제
+        );
+
+        return cacheManager;
+    }
+// 추후 분산 서버로 인한 레디스캐싱으로 변경 시 사용 예정
+//@Bean
+//public RedisCacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+//    // Jackson2JsonRedisSerializer로 JSON 직렬화 설정
+//    ObjectMapper objectMapper = new ObjectMapper();
+//    objectMapper.registerModule(new JavaTimeModule());
+//    objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+//
+//    RedisSerializer<Object> serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+//
+//    RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+//            .entryTtl(Duration.ofMinutes(30))
+//            .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(serializer));
+//
+//
+//    return RedisCacheManager.builder(redisConnectionFactory)
+//            .cacheDefaults(config)
+//            .build();
+//    }
+}

--- a/src/main/java/com/example/ticketable/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/ticketable/common/config/SecurityConfig.java
@@ -47,6 +47,7 @@ public class SecurityConfig {
 				.requestMatchers("/api/v1/stadiums/**").hasAuthority(MemberRole.Authority.ADMIN)
 				.requestMatchers("/api/v1/sections/**").hasAuthority(MemberRole.Authority.ADMIN)
 				.requestMatchers("/api/v1/seats/**").hasAuthority(MemberRole.Authority.ADMIN)
+				.requestMatchers("/actuator/prometheus").permitAll()
 				.anyRequest().authenticated()
 			);
 		

--- a/src/main/java/com/example/ticketable/domain/game/controller/GameController.java
+++ b/src/main/java/com/example/ticketable/domain/game/controller/GameController.java
@@ -30,7 +30,7 @@ public class GameController {
     public ResponseEntity<GameCreateResponse> createGame(
             @Valid @RequestPart(value = "json") GameCreateRequest request,
             @RequestPart(value = "image") MultipartFile file
-            ) {
+    ) {
         return ResponseEntity.ok(gameService.createGame(request, file));
     }
 
@@ -38,16 +38,38 @@ public class GameController {
     public ResponseEntity<List<GameGetResponse>> getGames(
             @RequestParam (required = false) String team,
             @RequestParam (required = false) LocalDateTime date
-            ) {
+    ) {
         return ResponseEntity.ok(gameService.getGames(team, date));
+    }
+
+    @GetMapping("/v0/games/{gameId}")
+    public ResponseEntity<StadiumGetResponse> getStadiumAndSectionSeatCountsV0(
+            @PathVariable Long gameId
+    ) {
+        return ResponseEntity.ok(gameService.getStadiumAndSectionSeatCountsV0(gameId));
     }
 
     @GetMapping("/v1/games/{gameId}")
     public ResponseEntity<StadiumGetResponse> getStadiumAndSectionSeatCounts(
             @PathVariable Long gameId
     ) {
-        return ResponseEntity.ok(gameService.getStadiumAndSectionSeatCounts(gameId));
+        return ResponseEntity.ok(gameService.getStadiumAndSectionSeatCountsV1(gameId));
     }
+
+    @GetMapping("/v2/games/{gameId}")
+    public ResponseEntity<StadiumGetResponse> getStadiumAndSectionSeatCountsV2(
+            @PathVariable Long gameId
+    ) {
+        return ResponseEntity.ok(gameService.getStadiumAndSectionSeatCountsV2(gameId));
+    }
+
+    @GetMapping("/v3/games/{gameId}")
+    public ResponseEntity<StadiumGetResponse> getStadiumAndSectionSeatCountsV3(
+            @PathVariable Long gameId
+    ) {
+        return ResponseEntity.ok(gameService.getStadiumAndSectionSeatCountsV3(gameId));
+    }
+
 
     @GetMapping("/v1/games/{gameId}/sectionTypes")
     public ResponseEntity<List<SectionSeatCountResponse>> getAvailableSeatsBySectionType(
@@ -75,7 +97,7 @@ public class GameController {
 
     @DeleteMapping("/v1/games/{gameId}")
     public ResponseEntity<Void> deleteGame(
-        @PathVariable Long gameId
+            @PathVariable Long gameId
     ) {
         gameService.deleteGames(gameId);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/example/ticketable/domain/game/entity/Game.java
+++ b/src/main/java/com/example/ticketable/domain/game/entity/Game.java
@@ -31,17 +31,19 @@ public class Game {
 	@Column(length = 20)
 	@Enumerated(EnumType.STRING)
 	private GameType type;
-	
+
 	private Integer point;
 
 	private String imagePath;
 
 	private LocalDateTime startTime;
 
+	private LocalDateTime ticketingStartTime;
+
 	private LocalDateTime deletedAt;
-	
+
 	@Builder
-	public Game(String away, Stadium stadium, String home, GameType type, Integer point, String imagePath, LocalDateTime startTime) {
+	public Game(String away, Stadium stadium, String home, GameType type, Integer point, String imagePath, LocalDateTime startTime, LocalDateTime ticketingStartTime) {
 		this.stadium = stadium;
 		this.away = away;
 		this.home = home;
@@ -49,6 +51,7 @@ public class Game {
 		this.point = point;
 		this.imagePath = imagePath;
 		this.startTime = startTime;
+		this.ticketingStartTime = ticketingStartTime;
 		this.deletedAt = null;
 	}
 

--- a/src/main/java/com/example/ticketable/domain/game/repository/GameRepository.java
+++ b/src/main/java/com/example/ticketable/domain/game/repository/GameRepository.java
@@ -13,7 +13,7 @@ import org.springframework.data.repository.query.Param;
 import java.time.LocalDateTime;
 import java.util.List;
 
-public interface GameRepository extends JpaRepository<Game, Long> {
+public interface GameRepository extends JpaRepository<Game, Long>, GameRepositoryQuery {
 
     List<Game> findByHomeAndStartTimeBetween(String team, LocalDateTime startOfDay, LocalDateTime endOfDay);
 
@@ -24,6 +24,88 @@ public interface GameRepository extends JpaRepository<Game, Long> {
     @Query("SELECT g.stadium From Game g where g.id = :gameId")
     Stadium getStadiumByGameId(@Param("gameId") Long gameId);
 
+
+//    // 타입별 예약되지 않는 좌석 수 쿼리 통합 버전
+//    @Query("""
+//    SELECT new com.example.ticketable.domain.stadium.dto.response.SectionTypeSeatCountResponse(
+//        s.type, COUNT(seat))
+//    FROM Seat seat
+//    JOIN seat.section s
+//    JOIN s.stadium st
+//    JOIN Game g ON g.stadium.id = st.id
+//    WHERE g.id = :gameId
+//      AND seat.id NOT IN (
+//        SELECT ts.seat.id
+//        FROM TicketSeat ts
+//        JOIN ts.ticket t
+//        WHERE t.game.id = :gameId
+//          AND t.deletedAt IS NULL
+//      )
+//    GROUP BY s.type
+//    """)
+//    List<SectionTypeSeatCountResponse> findUnBookedSeatsCountInSectionTypeByGameIdV1(
+//            @Param("gameId") Long gameId
+//    );
+//
+//
+//
+//    // 타입별 예약되지 않는 좌석 수 쿼리 통합 버전 & 서브 쿼리 삭제 버전`
+//    @Query("""
+//    SELECT new com.example.ticketable.domain.stadium.dto.response.SectionTypeSeatCountResponse(
+//        s.type, COUNT(seat))
+//    FROM Seat seat
+//    JOIN seat.section s
+//    JOIN s.stadium st
+//    JOIN Game g ON g.stadium.id = st.id
+//    LEFT JOIN TicketSeat ts ON ts.seat.id = seat.id
+//    LEFT JOIN Ticket t ON ts.ticket.id = t.id AND t.game.id = :gameId AND t.deletedAt IS NULL
+//    WHERE g.id = :gameId
+//        AND t.id IS NULL
+//    GROUP BY s.type
+//    """)
+//    List<SectionTypeSeatCountResponse> findUnBookedSeatsCountInSectionTypeByGameIdV2(
+//            @Param("gameId") Long gameId
+//    );
+
+    @Query("""
+SELECT new com.example.ticketable.domain.stadium.dto.response.SectionTypeSeatCountResponse(
+    s.type,
+    SUM(CASE 
+        WHEN t.id IS NULL OR t.deletedAt IS NOT NULL THEN 1
+        ELSE 0
+    END)
+)
+FROM Seat seat
+JOIN seat.section s
+JOIN s.stadium st
+JOIN Game g ON g.stadium.id = st.id
+LEFT JOIN TicketSeat ts ON ts.seat.id = seat.id
+LEFT JOIN Ticket t ON ts.ticket.id = t.id AND t.game.id = :gameId
+WHERE g.id = :gameId
+GROUP BY s.type
+""")
+    List<SectionTypeSeatCountResponse> findUnBookedSeatsCountInSectionTypeByGameIdV1(
+            @Param("gameId") Long gameId
+    );
+
+    @Query(value = """
+SELECT 
+    s.type AS section_type,
+    COUNT(seat.id) - COUNT(t.id) AS remaining_seats
+FROM Seat seat
+JOIN Section s ON seat.section_id = s.id
+JOIN Stadium st ON s.stadium_id = st.id
+JOIN Game g ON g.stadium_id = st.id
+LEFT JOIN Ticket_Seat ts ON ts.seat_id = seat.id
+LEFT JOIN Ticket t ON ts.ticket_id = t.id AND t.game_id = :gameId AND t.deleted_at IS NULL
+WHERE g.id = :gameId
+GROUP BY s.type
+""", nativeQuery = true)
+    List<SectionTypeSeatCountResponse> findUnBookedSeatsCountInSectionTypeByGameIdV2(@Param("gameId") Long gameId);
+
+
+
+    // 쿼리 통합 전 전체 좌석 수 조회
     @Query("""
     SELECT new com.example.ticketable.domain.stadium.dto.response.SectionTypeSeatCountResponse(
         s.type, COUNT(seat))
@@ -32,18 +114,30 @@ public interface GameRepository extends JpaRepository<Game, Long> {
     JOIN s.stadium st
     JOIN Game g ON g.stadium.id = st.id
     WHERE g.id = :gameId
-      AND seat.id NOT IN (
-        SELECT ts.seat.id
-        FROM TicketSeat ts
-        JOIN ts.ticket t
-        WHERE t.game.id = :gameId
-          AND t.deletedAt IS NULL
-      )
     GROUP BY s.type
     """)
-    List<SectionTypeSeatCountResponse> findUnBookedSeatsCountInSectionTypeByGameId(
+    List<SectionTypeSeatCountResponse> findTotalSeatsCountInSectionTypeByGameId(
             @Param("gameId") Long gameId
     );
+
+    // 쿼리 통합 전 예약된 좌석 수 조회 (구역 타입 기준)
+    @Query("""
+    SELECT new com.example.ticketable.domain.stadium.dto.response.SectionTypeSeatCountResponse(
+        s.type, COUNT(ts))
+    FROM TicketSeat ts
+    JOIN ts.seat seat
+    JOIN seat.section s
+    JOIN ts.ticket t
+    WHERE t.game.id = :gameId
+      AND t.deletedAt IS NULL
+    GROUP BY s.type
+    """)
+    List<SectionTypeSeatCountResponse> findBookedSeatsCountInSectionTypeByGameId(
+            @Param("gameId") Long gameId
+    );
+
+
+
 
     @Query("""
     SELECT new com.example.ticketable.domain.stadium.dto.response.SectionSeatCountResponse(

--- a/src/main/java/com/example/ticketable/domain/game/repository/GameRepositoryQuery.java
+++ b/src/main/java/com/example/ticketable/domain/game/repository/GameRepositoryQuery.java
@@ -1,0 +1,15 @@
+package com.example.ticketable.domain.game.repository;
+
+import com.example.ticketable.domain.auction.dto.AuctionTicketInfoDto;
+import com.example.ticketable.domain.auction.dto.request.AuctionSearchCondition;
+import com.example.ticketable.domain.auction.dto.response.AuctionResponse;
+import com.example.ticketable.domain.stadium.dto.response.SectionTypeSeatCountResponse;
+import com.example.ticketable.domain.ticket.entity.Ticket;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PagedModel;
+
+import java.util.List;
+
+public interface GameRepositoryQuery {
+    List<SectionTypeSeatCountResponse> findUnBookedSeatsCountInSectionTypeByGameIdV3(Long gameId);
+}

--- a/src/main/java/com/example/ticketable/domain/game/repository/GameRepositoryQueryImpl.java
+++ b/src/main/java/com/example/ticketable/domain/game/repository/GameRepositoryQueryImpl.java
@@ -1,0 +1,49 @@
+package com.example.ticketable.domain.game.repository;
+
+import com.example.ticketable.domain.game.entity.QGame;
+import com.example.ticketable.domain.stadium.dto.response.SectionTypeSeatCountResponse;
+import com.example.ticketable.domain.stadium.entity.QSeat;
+import com.example.ticketable.domain.stadium.entity.QSection;
+import com.example.ticketable.domain.stadium.entity.QStadium;
+import com.example.ticketable.domain.ticket.entity.QTicket;
+import com.example.ticketable.domain.ticket.entity.QTicketSeat;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class GameRepositoryQueryImpl implements GameRepositoryQuery {
+
+    private final JPAQueryFactory jpaQueryFactory;
+    public List<SectionTypeSeatCountResponse> findUnBookedSeatsCountInSectionTypeByGameIdV3(Long gameId) {
+        QSeat seat = QSeat.seat;
+        QSection section = QSection.section;
+        QStadium stadium = QStadium.stadium;
+        QGame game = QGame.game;
+        QTicketSeat ts = QTicketSeat.ticketSeat;
+        QTicket ticket = QTicket.ticket;
+
+        return jpaQueryFactory
+                .select(Projections.constructor(
+                        SectionTypeSeatCountResponse.class,
+                        section.type,
+                        new CaseBuilder()
+                                .when(ticket.id.isNull().or(ticket.deletedAt.isNotNull()))
+                                .then(1L)
+                                .otherwise(0L)
+                                .sum()
+                ))
+                .from(seat)
+                .join(seat.section, section)
+                .join(section.stadium, stadium)
+                .join(game).on(game.stadium.eq(stadium))
+                .leftJoin(ts).on(ts.seat.eq(seat))
+                .leftJoin(ticket).on(ts.ticket.eq(ticket).and(ticket.game.id.eq(gameId)))
+                .where(game.id.eq(gameId))
+                .groupBy(section.type)
+                .fetch();
+    }
+}

--- a/src/main/java/com/example/ticketable/domain/game/service/GameCacheService.java
+++ b/src/main/java/com/example/ticketable/domain/game/service/GameCacheService.java
@@ -1,0 +1,50 @@
+package com.example.ticketable.domain.game.service;
+
+import com.example.ticketable.common.exception.ErrorCode;
+import com.example.ticketable.common.exception.ServerException;
+import com.example.ticketable.domain.game.entity.Game;
+import com.example.ticketable.domain.game.repository.GameRepository;
+import com.example.ticketable.domain.game.util.GameCacheHelper;
+import com.example.ticketable.domain.stadium.dto.response.SectionTypeSeatCountResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class GameCacheService {
+    private final GameRepository gameRepository;
+    private final CacheManager cacheManager;
+    private final GameCacheHelper gameCacheHelper;
+
+
+    @Cacheable(value = "seatCountsBySectionType", key = "#gameId")
+    public List<SectionTypeSeatCountResponse> getSectionSeatCountsCached(Long gameId) {
+        log.info("💡 캐시 미적중! DB에서 seat count 조회 - gameId: {}", gameId);
+        return gameRepository.findUnBookedSeatsCountInSectionTypeByGameIdV2(gameId);
+    }
+
+
+
+    public void handleAfterTicketChange(Long gameId) {
+        Cache cache = cacheManager.getCache("seatCountsBySectionType");
+
+        if (gameCacheHelper.isEvictStrategy(gameId)) {
+            cache.evict(gameId);
+            log.info("캐시 삭제");
+        } else {
+            List<SectionTypeSeatCountResponse> updated =
+                    gameRepository.findUnBookedSeatsCountInSectionTypeByGameIdV2(gameId);
+            cache.put(gameId, updated);
+            log.info("캐시 갱신");
+        }
+    }
+}

--- a/src/main/java/com/example/ticketable/domain/game/util/GameCacheHelper.java
+++ b/src/main/java/com/example/ticketable/domain/game/util/GameCacheHelper.java
@@ -1,0 +1,23 @@
+package com.example.ticketable.domain.game.util;
+
+import com.example.ticketable.common.exception.ErrorCode;
+import com.example.ticketable.common.exception.ServerException;
+import com.example.ticketable.domain.game.entity.Game;
+import com.example.ticketable.domain.game.repository.GameRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class GameCacheHelper {
+    private final GameRepository gameRepository;
+
+    // 캐시 무효화 전략
+    public boolean isEvictStrategy(Long gameId) {
+        Game game = gameRepository.findById(gameId).orElseThrow(() -> new ServerException(ErrorCode.GAME_NOT_FOUND));
+        LocalDateTime now = LocalDateTime.now();
+        return now.isBefore(game.getTicketingStartTime().plusMinutes(30));
+    }
+}

--- a/src/main/java/com/example/ticketable/domain/ticket/service/TicketCreateService.java
+++ b/src/main/java/com/example/ticketable/domain/ticket/service/TicketCreateService.java
@@ -4,7 +4,6 @@ import static com.example.ticketable.common.exception.ErrorCode.GAME_NOT_FOUND;
 
 import com.example.ticketable.common.entity.Auth;
 import com.example.ticketable.common.exception.ServerException;
-import com.example.ticketable.common.util.SeatHoldRedisUtil;
 import com.example.ticketable.domain.game.entity.Game;
 import com.example.ticketable.domain.game.repository.GameRepository;
 import com.example.ticketable.domain.member.entity.Member;
@@ -14,6 +13,7 @@ import com.example.ticketable.domain.ticket.dto.TicketContext;
 import com.example.ticketable.domain.ticket.dto.request.TicketCreateRequest;
 import com.example.ticketable.domain.ticket.entity.Ticket;
 import com.example.ticketable.domain.ticket.repository.TicketRepository;
+
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/example/ticketable/domain/ticket/service/TicketService.java
+++ b/src/main/java/com/example/ticketable/domain/ticket/service/TicketService.java
@@ -8,6 +8,7 @@ import com.example.ticketable.common.entity.Auth;
 import com.example.ticketable.common.event.SeatHoldReleaseEvent;
 import com.example.ticketable.common.exception.ServerException;
 import com.example.ticketable.common.util.SeatHoldRedisUtil;
+import com.example.ticketable.domain.game.service.GameCacheService;
 import com.example.ticketable.domain.point.enums.PointHistoryType;
 import com.example.ticketable.domain.point.service.PointService;
 import com.example.ticketable.domain.ticket.dto.TicketContext;
@@ -35,11 +36,12 @@ public class TicketService {
 	private final TicketCreateService ticketCreateService;
 	private final SeatHoldRedisUtil seatHoldRedisUtil;
 	private final ApplicationEventPublisher eventPublisher;
+	private final GameCacheService gameCacheService;
 
 	@Transactional(readOnly = true)
 	public TicketResponse getTicket(Long ticketId) {
 		Ticket ticket = ticketRepository.findByIdWithGame(ticketId)
-			.orElseThrow(() -> new ServerException(TICKET_NOT_FOUND));
+				.orElseThrow(() -> new ServerException(TICKET_NOT_FOUND));
 
 		return convertTicketResponse(ticket);
 	}
@@ -62,6 +64,8 @@ public class TicketService {
 		ticketPaymentService.paymentTicket(ticketContext);
 
 		eventPublisher.publishEvent(new SeatHoldReleaseEvent(ticketCreateRequest.getSeats(), ticketCreateRequest.getGameId()));
+		// 캐싱 추가
+		gameCacheService.handleAfterTicketChange(ticketCreateRequest.getGameId());
 		return ticketContext.toResponse();
 	}
 
@@ -70,7 +74,7 @@ public class TicketService {
 
 		// 1. 티켓 취소 처리
 		Ticket ticket = ticketRepository.findByIdWithMember(ticketId)
-			.orElseThrow(() -> new ServerException(TICKET_NOT_FOUND));
+				.orElseThrow(() -> new ServerException(TICKET_NOT_FOUND));
 		if (auth.getRole() == ROLE_MEMBER && !auth.getId().equals(ticket.getMember().getId())) {
 			throw new ServerException(USER_ACCESS_DENIED);
 		}
@@ -81,6 +85,10 @@ public class TicketService {
 
 		// 3. 사용자 포인트 환불
 		pointService.increasePoint(ticket.getMember().getId(), refund, PointHistoryType.REFUND);
+
+		// 캐싱 삭제
+		Long gameId = ticket.getGame().getId();
+		gameCacheService.handleAfterTicketChange(gameId);
 	}
 
 	/**


### PR DESCRIPTION
## 📌 PR 요약
- 구역 타입 별 남은 좌석 쿼리 최적화
- 캐싱 적용
- 레디스 적용을 위한 사전 작업

## 🛠️ 변경 사항
- 주요 변경 사항을 bullet으로 작성해주세요.
    - 쿼리DSL, JPQL, native 쿼리 api 구분
    - 스케쥴러에 따른 캐싱 전략 변경
    - 테스트 코드 추가

## 📸 스크린샷 (선택)

| 기능 | 스크린샷 |
| --- | --- |
| 캐시 갱신 전략 테스트 결과| ![image](https://github.com/user-attachments/assets/e2a3540f-6a50-4d57-a3fd-4af9e1abf3fc) |
| 캐시 무효화 전략 테스트 결과| ![image](https://github.com/user-attachments/assets/1e4f4c2a-21b4-4535-8f74-f27ff38876f8) |

## ⚠️ 주의 사항 (선택)
조회 시 V2 버전을 선택해야 합니다.
또한 경기에서 Ticketing시작 시간 필드가 추가되었습니다.
티켓팅 시작 시간 + 30분을 기준으로 캐싱 전략이 변경됩니다.

## ✅ 체크리스트
PR 작성자가 확인해야 할 항목입니다:
- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] 코드 리뷰어를 등록했습니다.
- [x] Labels를 등록했습니다.